### PR TITLE
Migration of test_volume_network_ping_timeout.py

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -232,8 +232,8 @@ class IoOps(AbstractOps):
                 tmp_val[1] = tmp_val[1][15:].split('=')[1]
             if tmp_val[1].isdigit():
                 tmp_val[1] = float(tmp_val[1])
-            if tmp_val[1].is_integer():
-                tmp_val[1] = int(tmp_val[1])
+                if tmp_val[1].is_integer():
+                    tmp_val[1] = int(tmp_val[1])
             stat_res[tmp_val[0]] = tmp_val[1]
         ret_val['msg'] = stat_res
         return ret_val

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -232,8 +232,8 @@ class IoOps(AbstractOps):
                 tmp_val[1] = tmp_val[1][15:].split('=')[1]
             if tmp_val[1].isdigit():
                 tmp_val[1] = float(tmp_val[1])
-                if tmp_val[1].is_integer():
-                    tmp_val[1] = int(tmp_val[1])
+            if tmp_val[1].is_integer():
+                tmp_val[1] = int(tmp_val[1])
             stat_res[tmp_val[0]] = tmp_val[1]
         ret_val['msg'] = stat_res
         return ret_val
@@ -286,36 +286,6 @@ class IoOps(AbstractOps):
                f"--dirname-start-num {dir_start_no} --dir-depth {dir_depth}"
                f" --dir-length {dir_length} --max-num-of-dirs {max_no_dirs} "
                f"--num-of-files {no_files} {path}")
-        return self.execute_command_async(cmd, node)
-
-    def create_files(self, path: str, no_of_files: str, node: str,
-                     fixed_file_size: str = None,
-                     base_file_name: str = 'testfile',
-                     file_types: str = 'txt'):
-        """
-        Creates files. This function encapsulates the operation of the
-        creates_files script present in the client machines.
-        Args:
-            path (str): Path wherein this io is to be done.
-            no_of_files (str): Number of files to be created.
-        Kwargs:
-            fixed_file_size : Fixed file size. The sizes can be
-                              1k, 10k, 512k, 1M
-            base_file_name : Base file name
-            file_types: File Types to be created. File types can be txt, docx,
-                        empty_file separated with space. Defaults to 'txt'
-
-        """
-
-        cmd = f"python3 /tmp/file_dir_ops.py create_files -f {no_of_files} "
-        if file_types != 'txt':
-            cmd = cmd + f'--file-types {file_types} '
-        if fixed_file_size is not None:
-            cmd = cmd + f'--fixed-file-size {fixed_file_size} '
-        if base_file_name != 'testfile':
-            cmd = cmd + f'--base-file-name {base_file_name} '
-        cmd = cmd + path
-
         return self.execute_command_async(cmd, node)
 
     def get_file_permission(self, node: str, path: str) -> dict:

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -288,6 +288,36 @@ class IoOps(AbstractOps):
                f"--num-of-files {no_files} {path}")
         return self.execute_command_async(cmd, node)
 
+    def create_files(self, path: str, no_of_files: str, node: str,
+                     fixed_file_size: str = None,
+                     base_file_name: str = 'testfile',
+                     file_types: str = 'txt'):
+        """
+        Creates files. This function encapsulates the operation of the
+        creates_files script present in the client machines.
+        Args:
+            path (str): Path wherein this io is to be done.
+            no_of_files (str): Number of files to be created.
+        Kwargs:
+            fixed_file_size : Fixed file size. The sizes can be
+                              1k, 10k, 512k, 1M
+            base_file_name : Base file name
+            file_types: File Types to be created. File types can be txt, docx,
+                        empty_file separated with space. Defaults to 'txt'
+
+        """
+
+        cmd = f"python3 /tmp/file_dir_ops.py create_files -f {no_of_files} "
+        if file_types != 'txt':
+            cmd = cmd + f'--file-types {file_types} '
+        if fixed_file_size is not None:
+            cmd = cmd + f'--fixed-file-size {fixed_file_size} '
+        if base_file_name != 'testfile':
+            cmd = cmd + f'--base-file-name {base_file_name} '
+        cmd = cmd + path
+
+        return self.execute_command_async(cmd, node)
+
     def get_file_permission(self, node: str, path: str) -> dict:
         """
         Function to get file permissions.

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -46,9 +46,10 @@ class TestCase(NdParentTest):
         for mount in self.mounts:
             redant.logger.info(f"Starting IO on {mount['client']}:"
                                f"{mount['mountpath']}")
-            proc = redant.create_files(mount['mountpath'], 10,
-                                       mount['client'],
-                                       base_file_name='newfile')
+            proc = redant.create_files(num_files=1, fix_fil_size="1k",
+                                       path=mount['mountpath'],
+                                       node=mount['client'],
+                                       base_file_name="test_file")
             self.all_mounts_procs.append(proc)
 
         if not redant.validate_io_procs(self.all_mounts_procs, self.mounts):

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@
 #        of the volume.
 
 import re
-import sys
 
 from glusto.core import Glusto as g
 
@@ -113,9 +112,9 @@ class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_files -f 10 "
+            cmd = ("/usr/bin/env python %s create_files -f 10 "
                    "--base-file-name newfile %s" % (
-                       sys.version_info.major, self.script_upload_path,
+                       self.script_upload_path,
                        mount_obj.mountpoint))
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -96,7 +96,7 @@ class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
         # Mounting volume as glusterfs
         ret = self.mount_volume(self.mounts)
         self.assertTrue(ret, "volume mount failed for %s" % self.volname)
-        g.log.info("Volume mounted sucessfully : %s", self.volname)
+        g.log.info("Volume mounted successfully : %s", self.volname)
 
         # Checking volume mounted or not
         ret = is_mounted(self.volname, self.mounts[0].mountpoint, self.mnode,

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -1,181 +1,97 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 
-#  Description:
-#        Test Cases in this module related to Glusterd network ping timeout
-#        of the volume.
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+        Test Cases in this module related to Glusterd network ping timeout
+        of the volume.
+"""
 
 import re
-
-from glusto.core import Glusto as g
-
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.misc.misc_libs import upload_scripts
-from glustolibs.io.utils import (wait_for_io_to_complete,
-                                 list_all_files_and_dirs_mounts)
-from glustolibs.gluster.volume_ops import (get_volume_options,
-                                           set_volume_options)
-from glustolibs.gluster.mount_ops import is_mounted
-from glustolibs.io.utils import collect_mounts_arequal
+from tests.nd_parent_test import NdParentTest
 
 
-@runs_on([['distributed', 'replicated', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'], ['glusterfs']])
-class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-        g.log.info("Starting %s ", cls.__name__)
+# nonDisruptive;dist,rep,dist-rep,disp,dist-disp
+class TestCase(NdParentTest):
 
-        # Uploading file_dir script in all client direcotries
-        g.log.info("Upload io scripts to clients %s for running IO on "
-                   "mounts", cls.clients)
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts to clients %s"
-                                 % cls.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   cls.clients)
-
-    def setUp(self):
+    def run_test(self, redant):
         """
-        setUp method for every test
+        1) Create Volume
+        2) Mount the Volume
+        3) Create some files on mount point
+        4) calculate the checksum of Mount point
+        5) Check the default network ping timeout of the volume.
+        6) Change network ping timeout to some other value
+        7) calculate checksum again
+        8) checksum should be same without remounting the volume.
         """
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        # Creating Volume
-        g.log.info("Started creating volume")
-        ret = self.setup_volume()
-        if ret:
-            g.log.info("Volme created successfully : %s", self.volname)
-        else:
-            raise ExecutionError("Volume creation failed: %s" % self.volname)
-
-    def tearDown(self):
-        """
-        tearDown for every test
-        """
-        # unmounting the volume and Cleaning up the volume
-        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
-        if ret:
-            g.log.info("Volume deleted successfully : %s", self.volname)
-        else:
-            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_volume_checksum_after_changing_network_ping_timeout(self):
-
-        # Create Volume
-        # Mount the Volume
-        # Create some files on mount point
-        # calculate the checksum of Mount point
-        # Check the default network ping timeout of the volume.
-        # Change network ping timeout to some other value
-        # calculate checksum again
-        # checksum should be same without remounting the volume.
-
-        # Mounting volume as glusterfs
-        ret = self.mount_volume(self.mounts)
-        self.assertTrue(ret, "volume mount failed for %s" % self.volname)
-        g.log.info("Volume mounted successfully : %s", self.volname)
-
-        # Checking volume mounted or not
-        ret = is_mounted(self.volname, self.mounts[0].mountpoint, self.mnode,
-                         self.mounts[0].client_system, self.mount_type)
-        self.assertTrue(ret, "Volume not mounted on mount point: %s"
-                        % self.mounts[0].mountpoint)
-        g.log.info("Volume %s mounted on %s", self.volname,
-                   self.mounts[0].mountpoint)
 
         # run IOs
-        g.log.info("Starting IO on all mounts...")
+        redant.logger.info("Starting IO on all mounts...")
         self.all_mounts_procs = []
-        for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_files -f 10 "
-                   "--base-file-name newfile %s" % (
-                       self.script_upload_path,
-                       mount_obj.mountpoint))
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
+        self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
+        for mount in self.mounts:
+            redant.logger.info(f"Starting IO on {mount['client']}:"
+                               f"{mount['mountpath']}")
+            proc = redant.create_files(mount['mountpath'], 10,
+                                       mount['client'],
+                                       base_file_name='newfile')
             self.all_mounts_procs.append(proc)
 
-        # Validate IO
-        g.log.info("Wait for IO to complete and validate IO ...")
-        ret = wait_for_io_to_complete(self.all_mounts_procs, self.mounts)
-        self.assertTrue(ret, "IO failed on some of the clients")
-        g.log.info("IO is successful on all mounts")
+        if not redant.validate_io_procs(self.all_mounts_procs, self.mounts):
+            raise Exception("IO operations failed on some"
+                            " or all of the clients")
 
         # Checksum calculation of mount point before
         # changing network.ping-timeout
-        ret, before_checksum = collect_mounts_arequal(self.mounts)
-        self.assertTrue(ret, "checksum failed to calculate for mount point")
-        g.log.info("checksum calculated successfully")
+        before_checksum = redant.collect_mounts_arequal(self.mounts)
 
         # List all files and dirs created
-        g.log.info("List all files and directories:")
-        ret = list_all_files_and_dirs_mounts(self.mounts)
-        self.assertTrue(ret, "Failed to list all files and dirs")
-        g.log.info("Listing all files and directories is successful")
+        redant.logger.info("List all files and directories:")
+        ret = redant.list_all_files_and_dirs_mounts(self.mounts)
+        if not ret:
+            raise Exception("Failed to list all files and dirs")
 
         # performing gluster volume get volname all and
         # getting network ping time out value
-        volume_options = get_volume_options(self.mnode, self.volname, "all")
-        self.assertIsNotNone(volume_options, "gluster volume get %s all "
-                                             "command failed" % self.volname)
-        g.log.info("gluster volume get %s all command executed "
-                   "successfully", self.volname)
+        volume_options = redant.get_volume_options(self.vol_name,
+                                                   node=self.server_list[0])
         ret = False
         if re.search(r'\b42\b', volume_options['network.ping-timeout']):
             ret = True
-        self.assertTrue(ret, "network ping time out value is not correct")
-        g.log.info("network ping time out value is correct")
+        if not ret:
+            raise Exception("network ping time out value is not correct")
 
         # Changing network ping time out value to specific volume
-        self.networking_ops = {'network.ping-timeout': '12'}
-        ret = set_volume_options(self.mnode, self.volname,
-                                 self.networking_ops)
-        self.assertTrue(ret, "Changing of network.ping-timeout "
-                             "failed for :%s" % self.volname)
-        g.log.info("Changing of network.ping-timeout "
-                   "success for :%s", self.volname)
+        networking_ops = {'network.ping-timeout': '12'}
+        ret = redant.set_volume_options(self.vol_name, networking_ops,
+                                        self.server_list[0])
 
         # Checksum calculation of mount point after
         # changing network.ping-timeout
-        ret, after_checksum = collect_mounts_arequal(self.mounts)
-        self.assertTrue(ret, "checksum failed to calculate for mount point")
-        g.log.info("checksum calculated successfully")
+        after_checksum = redant.collect_mounts_arequal(self.mounts)
 
         # comparing list of checksums of mountpoints before and after
         # network.ping-timeout change
-        self.assertItemsEqual(before_checksum, after_checksum,
-                              "Checksum not same before and after "
-                              "network.ping-timeout change")
-        g.log.info("checksum same before and after "
-                   "changing network.ping-timeout")
+        if before_checksum != after_checksum:
+            raise Exception("Checksum not same before and after "
+                            "network.ping-timeout change")
 
         # List all files and dirs created
-        g.log.info("List all files and directories:")
-        ret = list_all_files_and_dirs_mounts(self.mounts)
-        self.assertTrue(ret, "Failed to list all files and dirs")
-        g.log.info("Listing all files and directories is successful")
+        redant.logger.info("List all files and directories:")
+        ret = redant.list_all_files_and_dirs_mounts(self.mounts)
+        if not ret:
+            raise Exception("Failed to list all files and dirs")

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -45,11 +45,9 @@ class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                   "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, script_local_path)
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts to clients %s"
                                  % cls.clients)

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -19,7 +19,10 @@
 #        of the volume.
 
 import re
+import sys
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.misc.misc_libs import upload_scripts
@@ -36,7 +39,7 @@ from glustolibs.io.utils import collect_mounts_arequal
 class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         g.log.info("Starting %s ", cls.__name__)
 
         # Uploading file_dir script in all client direcotries
@@ -58,7 +61,7 @@ class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
         setUp method for every test
         """
         # calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # Creating Volume
         g.log.info("Started creating volume")
@@ -80,7 +83,7 @@ class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
             raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_volume_checksum_after_changing_network_ping_timeout(self):
 
@@ -112,8 +115,10 @@ class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_files -f 10 --base-file-name newfile %s"
-                   % (self.script_upload_path, mount_obj.mountpoint))
+            cmd = ("/usr/bin/env python%d %s create_files -f 10 "
+                   "--base-file-name newfile %s" % (
+                       sys.version_info.major, self.script_upload_path,
+                       mount_obj.mountpoint))
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)
             self.all_mounts_procs.append(proc)

--- a/tests/functional/glusterd/test_volume_network_ping_timeout.py
+++ b/tests/functional/glusterd/test_volume_network_ping_timeout.py
@@ -1,0 +1,179 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#  Description:
+#        Test Cases in this module related to Glusterd network ping timeout
+#        of the volume.
+
+import re
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.misc.misc_libs import upload_scripts
+from glustolibs.io.utils import (wait_for_io_to_complete,
+                                 list_all_files_and_dirs_mounts)
+from glustolibs.gluster.volume_ops import (get_volume_options,
+                                           set_volume_options)
+from glustolibs.gluster.mount_ops import is_mounted
+from glustolibs.io.utils import collect_mounts_arequal
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
+class CheckVolumeChecksumAfterChangingNetworkPingTimeOut(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+        g.log.info("Starting %s ", cls.__name__)
+
+        # Uploading file_dir script in all client direcotries
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", cls.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts to clients %s"
+                                 % cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+    def setUp(self):
+        """
+        setUp method for every test
+        """
+        # calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+
+        # Creating Volume
+        g.log.info("Started creating volume")
+        ret = self.setup_volume()
+        if ret:
+            g.log.info("Volme created successfully : %s", self.volname)
+        else:
+            raise ExecutionError("Volume creation failed: %s" % self.volname)
+
+    def tearDown(self):
+        """
+        tearDown for every test
+        """
+        # unmounting the volume and Cleaning up the volume
+        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
+        if ret:
+            g.log.info("Volume deleted successfully : %s", self.volname)
+        else:
+            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_volume_checksum_after_changing_network_ping_timeout(self):
+
+        # Create Volume
+        # Mount the Volume
+        # Create some files on mount point
+        # calculate the checksum of Mount point
+        # Check the default network ping timeout of the volume.
+        # Change network ping timeout to some other value
+        # calculate checksum again
+        # checksum should be same without remounting the volume.
+
+        # Mounting volume as glusterfs
+        ret = self.mount_volume(self.mounts)
+        self.assertTrue(ret, "volume mount failed for %s" % self.volname)
+        g.log.info("Volume mounted sucessfully : %s", self.volname)
+
+        # Checking volume mounted or not
+        ret = is_mounted(self.volname, self.mounts[0].mountpoint, self.mnode,
+                         self.mounts[0].client_system, self.mount_type)
+        self.assertTrue(ret, "Volume not mounted on mount point: %s"
+                        % self.mounts[0].mountpoint)
+        g.log.info("Volume %s mounted on %s", self.volname,
+                   self.mounts[0].mountpoint)
+
+        # run IOs
+        g.log.info("Starting IO on all mounts...")
+        self.all_mounts_procs = []
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_files -f 10 --base-file-name newfile %s"
+                   % (self.script_upload_path, mount_obj.mountpoint))
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+
+        # Validate IO
+        g.log.info("Wait for IO to complete and validate IO ...")
+        ret = wait_for_io_to_complete(self.all_mounts_procs, self.mounts)
+        self.assertTrue(ret, "IO failed on some of the clients")
+        g.log.info("IO is successful on all mounts")
+
+        # Checksum calculation of mount point before
+        # changing network.ping-timeout
+        ret, before_checksum = collect_mounts_arequal(self.mounts)
+        self.assertTrue(ret, "checksum failed to calculate for mount point")
+        g.log.info("checksum calculated successfully")
+
+        # List all files and dirs created
+        g.log.info("List all files and directories:")
+        ret = list_all_files_and_dirs_mounts(self.mounts)
+        self.assertTrue(ret, "Failed to list all files and dirs")
+        g.log.info("Listing all files and directories is successful")
+
+        # performing gluster volume get volname all and
+        # getting network ping time out value
+        volume_options = get_volume_options(self.mnode, self.volname, "all")
+        self.assertIsNotNone(volume_options, "gluster volume get %s all "
+                                             "command failed" % self.volname)
+        g.log.info("gluster volume get %s all command executed "
+                   "successfully", self.volname)
+        ret = False
+        if re.search(r'\b42\b', volume_options['network.ping-timeout']):
+            ret = True
+        self.assertTrue(ret, "network ping time out value is not correct")
+        g.log.info("network ping time out value is correct")
+
+        # Changing network ping time out value to specific volume
+        self.networking_ops = {'network.ping-timeout': '12'}
+        ret = set_volume_options(self.mnode, self.volname,
+                                 self.networking_ops)
+        self.assertTrue(ret, "Changing of network.ping-timeout "
+                             "failed for :%s" % self.volname)
+        g.log.info("Changing of network.ping-timeout "
+                   "success for :%s", self.volname)
+
+        # Checksum calculation of mount point after
+        # changing network.ping-timeout
+        ret, after_checksum = collect_mounts_arequal(self.mounts)
+        self.assertTrue(ret, "checksum failed to calculate for mount point")
+        g.log.info("checksum calculated successfully")
+
+        # comparing list of checksums of mountpoints before and after
+        # network.ping-timeout change
+        self.assertItemsEqual(before_checksum, after_checksum,
+                              "Checksum not same before and after "
+                              "network.ping-timeout change")
+        g.log.info("checksum same before and after "
+                   "changing network.ping-timeout")
+
+        # List all files and dirs created
+        g.log.info("List all files and directories:")
+        ret = list_all_files_and_dirs_mounts(self.mounts)
+        self.assertTrue(ret, "Failed to list all files and dirs")
+        g.log.info("Listing all files and directories is successful")


### PR DESCRIPTION
Migration of [test_volume_network_ping_timeout.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_volume_network_ping_timeout.py)  from glusto to redant.                            
                                                                                 
Updates: #292                                                                   
Fixes: #539                                                                                                         
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>