### PR TITLE
Used f strings in rmdir

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -1125,9 +1125,9 @@ class IoOps(AbstractOps):
         cmd = "rmdir"
         if force:
             cmd = "rm"
-            cmd += " -rf"
+            cmd = f"{cmd} -rf"
 
-        cmd += f" {fqpath}"
+        cmd = f"{cmd} {fqpath}"
         ret = self.execute_abstract_op_node(cmd, node, False)
 
         if ret['error_code'] != 0:


### PR DESCRIPTION
Used f-strings in place of + in rmdir function.

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
