### PR TITLE
[TestMigration] Migration of activate/deactivate snap test.

### DIFF
--- a/common/ops/gluster_ops/snapshot_ops.py
+++ b/common/ops/gluster_ops/snapshot_ops.py
@@ -445,7 +445,9 @@ class SnapshotOps(AbstractOps):
             temp_name = snap['name']
             del snap['name']
             snap_info_dict[temp_name] = copy.deepcopy(snap)
-        return None
+        if snap_info_dict == {}:
+            return None
+        return snap_info_dict
 
     def get_snap_info_by_snapname(self, snapname: str, node: str) -> dict:
         """
@@ -487,7 +489,9 @@ class SnapshotOps(AbstractOps):
                 temp_dict = copy.deepcopy(snap_info_dict[snap])
                 del temp_dict['snapVolume']['originVolume']
                 snap_vol_dict[snap] = copy.deepcopy(temp_dict)
-        return None
+        if snap_vol_dict == {}:
+            return None
+        return snap_vol_dict
 
     def snap_list(self, node: str, excep: bool = True) -> dict:
         """

--- a/tests/functional/snapshot/test_activate_deactivate.py
+++ b/tests/functional/snapshot/test_activate_deactivate.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020 Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -58,23 +58,15 @@ class TestActivateDeactivate(GlusterBaseClass):
         if ret != 0:
             raise ExecutionError("Snapshot Delete Failed")
         g.log.info("Successfully deleted all snapshots")
+
+        # Cleanup-volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Cleanup Volume")
+        g.log.info("Successful in Cleanup Volume")
+
         # Calling GlusterBaseClass tearDown
         self.get_super_method(self, 'tearDown')()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Clean up the volume & mount
-        """
-        # stopping the volume and clean up the volume
-        g.log.info("Starting to Cleanup Volume")
-        ret = cls.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Cleanup Volume and mount")
-        g.log.info("Successful in Cleanup Volume and mount")
-
-        # calling GlusterBaseClass tearDownClass
-        cls.get_super_method(cls, 'tearDownClass')()
 
     def test_activate_deactivate(self):
         # pylint: disable=too-many-branches, too-many-statements

--- a/tests/functional/snapshot/test_activate_deactivate.py
+++ b/tests/functional/snapshot/test_activate_deactivate.py
@@ -14,6 +14,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+    Verifying snapshot activation and deactivation functionality
+as well as snap info and status output.
 """
 
 
@@ -25,7 +29,6 @@ from tests.d_parent_test import DParentTest
 class TestCase(DParentTest):
 
     def run_test(self, redant):
-        # pylint: disable=too-many-branches, too-many-statements
         """
         Verifying Snapshot activation/deactivation functionality.
 

--- a/tests/functional/snapshot/test_activate_deactivate.py
+++ b/tests/functional/snapshot/test_activate_deactivate.py
@@ -1,74 +1,30 @@
-#  Copyright (C) 2017-2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-    Description:
-        The purpose of this test case is to validate Snapshot
-        activation and deactivation.
-        Pre-Activate, Post-Activate and Post-Deactivate
+Copyright (C) 2017-2020 Red Hat, Inc. <http://www.redhat.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.snap_ops import (snap_create,
-                                         snap_delete_all,
-                                         snap_activate,
-                                         snap_deactivate,
-                                         get_snap_info_by_snapname,
-                                         get_snap_status_by_snapname)
 
 
-@runs_on([['replicated', 'distributed', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'],
-          ['glusterfs']])
-class TestActivateDeactivate(GlusterBaseClass):
-    @classmethod
-    def setUpClass(cls):
-        """
-        setup volume and initialize necessary variables
-        """
+from tests.d_parent_test import DParentTest
 
-        cls.get_super_method(cls, 'setUpClass')()
-        g.log.info("Starting %s:", cls.__name__)
-        # Setup volume and mount
-        g.log.info("Starting to Setup Volume")
-        ret = cls.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume")
-        g.log.info("Successful in Setup Volume")
+# disruptive;rep,dist,dist-rep,disp,dist-disp
 
-    def tearDown(self):
-        """
-        tearDown for every test
-        """
-        ret, _, _ = snap_delete_all(self.mnode)
-        if ret != 0:
-            raise ExecutionError("Snapshot Delete Failed")
-        g.log.info("Successfully deleted all snapshots")
 
-        # Cleanup-volume
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Cleanup Volume")
-        g.log.info("Successful in Cleanup Volume")
+class TestCase(DParentTest):
 
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_activate_deactivate(self):
+    def run_test(self, redant):
         # pylint: disable=too-many-branches, too-many-statements
         """
         Verifying Snapshot activation/deactivation functionality.
@@ -85,88 +41,58 @@ class TestActivateDeactivate(GlusterBaseClass):
         """
 
         # Create Snapshot
-        snap_name = 'snap_%s' % self.volname
-        g.log.info("Starting to Create Snapshot %s", snap_name)
-        ret, _, _ = snap_create(self.mnode, self.volname, snap_name)
-        self.assertEqual(ret, 0, ("Snapshot Creation failed for %s",
-                                  snap_name))
-        g.log.info("Successfully created Snapshot %s for volume %s",
-                   snap_name, self.volname)
+        snap_name = f"{self.vol_name}-snap"
+        redant.snap_create(self.vol_name, snap_name, self.server_list[0])
 
         # Validate Snapshot Info Before Activation
-        g.log.info("Validating 'snapshot info' in 'stopped' state before "
-                   "activating the snapshot")
-        ret = get_snap_info_by_snapname(self.mnode, snap_name)
-        self.assertIsNotNone(ret, ("Failed to Fetch Snapshot info for %s",
-                                   snap_name))
-        g.log.info("Snapshot info Success for %s", ret['snapVolume']['status'])
-        self.assertEqual(ret['snapVolume']['status'], 'Stopped',
-                         ("Unexpected: Snapshot %s Status is in Started state",
-                          snap_name))
-        g.log.info("Expected: Snapshot is in Stopped state as it is "
-                   "not Activated")
+        ret = redant.get_snap_info_by_snapname(snap_name, self.server_list[0])
+        if ret is None:
+            raise Exception(f"Snap info for {snap_name} not found")
+        if ret['snapVolume']['status'] != 'Stopped':
+            raise Exception("Snap status should be stopped before activation.")
 
         # Validate Snapshot Status Before Activation
-        g.log.info("Validating 'snapshot status' in 'stopped' state before "
-                   "activating the snapshot")
-        ret = get_snap_status_by_snapname(self.mnode, snap_name)
-        self.assertIsNotNone(ret, ("Failed to Fetch Snapshot status for %s",
-                                   snap_name))
-        g.log.info("Snapshot Status Success for %s", snap_name)
+        ret = redant.get_snap_status_by_snapname(snap_name,
+                                                 self.server_list[0])
         for brick in ret['volume']['brick']:
-            self.assertEqual(brick['pid'], 'N/A',
-                             ("Unexpected: Brick Pid '%s' is available for %s",
-                              brick['pid'], brick['path']))
-        g.log.info("Expected: Deactivated Snapshot Brick PID is 'N/A'")
+            if brick['pid'] != 'N/A':
+                raise Exception("Unexpected. Brick pid available for the brick"
+                                f" {brick['path']} as {brick['pid']}")
 
         # Activate Snapshot
-        g.log.info("Starting to Activate %s", snap_name)
-        ret, _, _ = snap_activate(self.mnode, snap_name)
-        self.assertEqual(ret, 0, ("Snapshot Activation Failed for %s",
-                                  snap_name))
-        g.log.info("Snapshot %s Activated Successfully", snap_name)
+        redant.snap_activate(snap_name, self.server_list[0])
 
         # Validate Snapshot Info After Activation
-        g.log.info("Validating 'snapshot info' in 'started' state after"
-                   " activating the snapshot")
-        snap_info = get_snap_info_by_snapname(self.mnode, snap_name)
-        self.assertEqual(snap_info['snapVolume']['status'], "Started",
-                         ("Failed to Fetch Snapshot info after activate "
-                          "for %s", snap_name))
-        g.log.info("Success: Snapshot info in 'started' state")
+        ret = redant.get_snap_info_by_snapname(snap_name, self.server_list[0])
+        if ret is None:
+            raise Exception(f"Snap info for {snap_name} not found")
+        if ret['snapVolume']['status'] == 'Stopped':
+            raise Exception("Snap status shouldn't be stopped after"
+                            " activation.")
 
         # Validate Snaphot Status After Activation
-        g.log.info("Validating 'snapshot status' in started state after "
-                   "activating the snapshot")
-        ret = get_snap_status_by_snapname(self.mnode, snap_name)
+        ret = redant.get_snap_status_by_snapname(snap_name,
+                                                 self.server_list[0])
         for brick in ret['volume']['brick']:
-            self.assertNotEqual(brick['pid'], 'N/A',
-                                ("Brick Path %s  Not Available for Activated "
-                                 "Snapshot %s", (brick['path'], snap_name)))
-        g.log.info("Sucessfully validated Activated Snapshot Brick Path "
-                   "Available")
+            if brick['pid'] == 'N/A':
+                raise Exception(f"Unexpected. Brick pid for {brick['path']}"
+                                " shouldn't be N/A")
 
         # Deactivate Snapshot
-        g.log.info("Starting to Deactivate %s", snap_name)
-        ret, _, _ = snap_deactivate(self.mnode, snap_name)
-        self.assertEqual(ret, 0, ("Snapshot Deactivation Failed for %s",
-                                  snap_name))
-        g.log.info("Successfully Deactivated Snapshot %s", snap_name)
+        redant.snap_deactivate(snap_name, self.server_list[0])
 
         # Validate Snapshot Info After Deactivation
-        g.log.info("Validating 'snapshot info' in stopped state after "
-                   "deactivating the snapshot")
-        ret = get_snap_info_by_snapname(self.mnode, snap_name)
-        self.assertEqual(ret['snapVolume']['status'], 'Stopped',
-                         ("Snapshot Status is not in 'Stopped' State"))
-        g.log.info("Expected: Snapshot is in Stopped state after Deactivation")
+        ret = redant.get_snap_info_by_snapname(snap_name, self.server_list[0])
+        if ret is None:
+            raise Exception(f"Snap info for {snap_name} not found")
+        if ret['snapVolume']['status'] != 'Stopped':
+            raise Exception("Snap status should be stopped after"
+                            " de-activation.")
 
         # Validate Snaphot Status After Deactivation
-        g.log.info("Validating 'snapshot status' in started state after "
-                   "deactivating the snapshot")
-        ret = get_snap_status_by_snapname(self.mnode, snap_name)
+        ret = redant.get_snap_status_by_snapname(snap_name,
+                                                 self.server_list[0])
         for brick in ret['volume']['brick']:
-            self.assertEqual(brick['pid'], 'N/A',
-                             ("Deactivated Snapshot Brick Pid %s available "
-                              "for %s", brick['pid'], brick['path']))
-        g.log.info("Expected: Deactivated Snapshot Brick PID is 'N/A'")
+            if brick['pid'] != 'N/A':
+                raise Exception("Unexpected. Brick pid available for the brick"
+                                f" {brick['path']} as {brick['pid']}")

--- a/tests/functional/snapshot/test_activate_deactivate.py
+++ b/tests/functional/snapshot/test_activate_deactivate.py
@@ -1,0 +1,170 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+    Description:
+        The purpose of this test case is to validate Snapshot
+        activation and deactivation.
+        Pre-Activate, After Activate and After Deactivate
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.snap_ops import (snap_create,
+                                         snap_delete_all,
+                                         snap_activate,
+                                         snap_deactivate,
+                                         get_snap_info_by_snapname,
+                                         get_snap_status_by_snapname)
+
+
+@runs_on([['replicated', 'distributed', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'],
+          ['glusterfs']])
+class TestActivateDeactivate(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        """
+        setup volume and initialize necessary variables
+        """
+
+        GlusterBaseClass.setUpClass.im_func(cls)
+        g.log.info("Starting %s:", cls.__name__)
+        # Setup volume and mount
+        g.log.info("Starting to Setup Volume")
+        ret = cls.setup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume")
+        g.log.info("Successful in Setup Volume")
+
+    def tearDown(self):
+        """
+        tearDown for every test
+        """
+        ret, _, _ = snap_delete_all(self.mnode)
+        if ret != 0:
+            raise ExecutionError("Snapshot Delete Failed")
+        g.log.info("Successfully deleted all snapshots")
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean up the volume & mount
+        """
+        # stopping the volume and clean up the volume
+        g.log.info("Starting to Cleanup Volume")
+        ret = cls.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Cleanup Volume and mount")
+        g.log.info("Successful in Cleanup Volume and mount")
+
+        # calling GlusterBaseClass tearDownClass
+        GlusterBaseClass.tearDownClass.im_func(cls)
+
+    def test_activate_deactivate(self):
+        # pylint: disable=too-many-branches, too-many-statements
+        """
+        Verifying Snapshot activation/deactivation functionality.
+        """
+        snap_name = 'snap_%s' % self.volname
+        # Create Snapshot
+        g.log.info("Starting to Create Snapshot %s", snap_name)
+        ret, _, _ = snap_create(self.mnode, self.volname,
+                                snap_name)
+        self.assertEqual(ret, 0, "Snapshot Creation failed"
+                         " for %s" % snap_name)
+        g.log.info("Snapshot %s of volume %s created"
+                   " successfully", snap_name, self.volname)
+
+        # Validate Snapshot Info Before Activation
+        ret = get_snap_info_by_snapname(self.mnode, snap_name)
+        if ret is None:
+            raise ExecutionError("Failed to Fetch Snapshot"
+                                 "info for %s" % snap_name)
+        g.log.info("Snapshot info Success"
+                   "for %s", ret['snapVolume']['status'])
+        if ret['snapVolume']['status'] != 'Stopped':
+            raise ExecutionError("Unexpected: "
+                                 "Snapshot %s Status is in "
+                                 "Started State" % snap_name)
+        g.log.info("Expected: Snapshot is in Stopped state "
+                   "as it is not Activated")
+
+        # Validate Snapshot Status Before Activation
+        ret = get_snap_status_by_snapname(self.mnode, snap_name)
+        if ret is None:
+            raise ExecutionError("Failed to Fetch Snapshot"
+                                 "status for %s" % snap_name)
+        g.log.info("Snapshot Status Success for %s", snap_name)
+        for brick in ret['volume']['brick']:
+            if brick['pid'] != 'N/A':
+                raise ExecutionError("Brick Pid %s available for %s"
+                                     % brick['pid'], brick['path'])
+        g.log.info("Deactivated Snapshot Brick PID N/A as Expected")
+
+        # Activate Snapshot
+        g.log.info("Starting to Activate %s", snap_name)
+        ret, _, _ = snap_activate(self.mnode, snap_name)
+        self.assertEqual(ret, 0, "Snapshot Activation Failed"
+                         " for %s" % snap_name)
+        g.log.info("Snapshot %s Activated Successfully", snap_name)
+
+        # Validate Snapshot Info After Activation
+        g.log.info("Validate snapshot info")
+        snap_info = get_snap_info_by_snapname(self.mnode, snap_name)
+        self.assertEqual(snap_info['snapVolume']['status'], "Started",
+                         "Failed to Fetch Snapshot"
+                         "info after activate "
+                         "for %s" % snap_name)
+        g.log.info("Snapshot info Success ")
+
+        # Validate Snaphot Status After Activation
+        g.log.info("Validate snapshot status")
+        ret = get_snap_status_by_snapname(self.mnode, snap_name)
+        for brick in ret['volume']['brick']:
+            self.assertNotEqual(brick['pid'], 'N/A', "Brick Path "
+                                "%s  Not Available "
+                                "for Activated Snapshot %s"
+                                % (brick['path'], snap_name))
+        g.log.info("Activated Snapshot Brick Path "
+                   "Available as Expected")
+
+        # Validation After Snapshot Deactivate
+        g.log.info("Starting to Deactivate %s", snap_name)
+        ret, _, _ = snap_deactivate(self.mnode, snap_name)
+        self.assertEqual(ret, 0, "Snapshot Deactivation Failed"
+                         " for %s" % snap_name)
+        g.log.info("Snapshot %s Deactivation Successfully", snap_name)
+
+        # Validate Snapshot Info After Deactivation
+        ret = get_snap_info_by_snapname(self.mnode, snap_name)
+        self.assertEqual(ret['snapVolume']['status'], 'Stopped',
+                         "Snapshot Status is not "
+                         "in Stopped State")
+        g.log.info("Snapshot is in Stopped state after Deactivation")
+
+        # Validate Snaphot Status After Activation
+        g.log.info("Validate snapshot status")
+        ret = get_snap_status_by_snapname(self.mnode, snap_name)
+        for brick in ret['volume']['brick']:
+            self.assertEqual(brick['pid'], 'N/A', "Deactivated "
+                             "Snapshot Brick "
+                             "Pid %s available "
+                             "for %s"
+                             % (brick['pid'], brick['path']))
+        g.log.info("Deactivated Snapshot Brick PID N/A as Expected")

--- a/tests/functional/snapshot/test_activate_deactivate.py
+++ b/tests/functional/snapshot/test_activate_deactivate.py
@@ -41,7 +41,7 @@ class TestActivateDeactivate(GlusterBaseClass):
         setup volume and initialize necessary variables
         """
 
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         g.log.info("Starting %s:", cls.__name__)
         # Setup volume and mount
         g.log.info("Starting to Setup Volume")
@@ -59,7 +59,7 @@ class TestActivateDeactivate(GlusterBaseClass):
             raise ExecutionError("Snapshot Delete Failed")
         g.log.info("Successfully deleted all snapshots")
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     @classmethod
     def tearDownClass(cls):
@@ -74,7 +74,7 @@ class TestActivateDeactivate(GlusterBaseClass):
         g.log.info("Successful in Cleanup Volume and mount")
 
         # calling GlusterBaseClass tearDownClass
-        GlusterBaseClass.tearDownClass.im_func(cls)
+        cls.get_super_method(cls, 'tearDownClass')()
 
     def test_activate_deactivate(self):
         # pylint: disable=too-many-branches, too-many-statements


### PR DESCRIPTION
    The test case in glusto being,
    [Test](https://github.com/gluster/glusto-tests/blob/master/tests/functional/snapshot/test_activate_deactivate.py)
    
    Updates: #292
    
    Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>