### PR TITLE
[Common] Renaming gluster ops to glusterd ops.

### DIFF
--- a/common/mixin.py
+++ b/common/mixin.py
@@ -9,7 +9,7 @@ from .ops.support_ops.io_ops import IoOps
 from .ops.support_ops.machine_ops import MachineOps
 from .ops.gluster_ops.peer_ops import PeerOps
 from .ops.gluster_ops.volume_ops import VolumeOps
-from .ops.gluster_ops.gluster_ops import GlusterOps
+from .ops.gluster_ops.glusterd_ops import GlusterdOps
 from .ops.gluster_ops.brick_ops import BrickOps
 from .ops.gluster_ops.profile_ops import ProfileOps
 from .ops.gluster_ops.rebalance_ops import RebalanceOps
@@ -22,7 +22,7 @@ from .ops.gluster_ops.snapshot_ops import SnapshotOps
 from .ops.gluster_ops.glusterfind_ops import GlusterfindOps
 
 
-class RedantMixin(GlusterOps, VolumeOps, BrickOps, PeerOps,
+class RedantMixin(GlusterdOps, VolumeOps, BrickOps, PeerOps,
                   IoOps, MachineOps, MountOps, ProfileOps, RebalanceOps,
                   HealOps, SharedStorageOps, AuthOps, BitrotOps, SnapshotOps,
                   GlusterfindOps, Rexe, Logger):

--- a/common/ops/gluster_ops/glusterd_ops.py
+++ b/common/ops/gluster_ops/glusterd_ops.py
@@ -1,5 +1,5 @@
 """
-This file contains one class - GlusterOps wich holds
+This file contains one class - GlusterdOps wich holds
 operations on the glusterd service on the server
 or the client.
 """
@@ -8,7 +8,7 @@ import configparser
 from common.ops.abstract_ops import AbstractOps
 
 
-class GlusterOps(AbstractOps):
+class GlusterdOps(AbstractOps):
     """
     GlusterOps class provides APIs to start and stop
     the glusterd service on either the client or the sever.

--- a/docs/BP/Ops/glusterd_ops.md
+++ b/docs/BP/Ops/glusterd_ops.md
@@ -1,6 +1,6 @@
 # Glusterd Ops
 
-[Glusterd Ops](../../../common/ops/gluster_ops/gluster_ops.py) contains all the functions which are required for glusterd specific operations.
+[Glusterd Ops](../../../common/ops/gluster_ops/glusterd_ops.py) contains all the functions which are required for glusterd specific operations.
 
 ## Given below are all the details about all the functions implemented in the Glusterd Ops module:
 


### PR DESCRIPTION
More of a nomenclature issue. Also reduces confusion
if any rises in future with the ops name.

Fixes: #807

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
