### PR TITLE
Migrated TC test_glusterfind_when_node_down

### DIFF
--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -20,8 +20,6 @@ class MachineOps(AbstractOps):
         To reboot a given set of node(s)
         Arg:
             node(s) (str/list)
-        Returns:
-            None
         """
         if not isinstance(nodes, list):
             nodes = [nodes]
@@ -77,10 +75,6 @@ class MachineOps(AbstractOps):
         Returns:
             bool value: True if node is online or False.
         """
-        status = self.check_node_power_status(node)
-        if status[node]:
-            self.logger.info(f"{node} online.")
-            return True
         iter_v = 0
         while iter_v < timeout:
             status = self.check_node_power_status(node)
@@ -89,10 +83,7 @@ class MachineOps(AbstractOps):
                 return True
             time.sleep(1)
             iter_v += 1
-        status = self.check_node_power_status(node)
-        if status[node]:
-            self.logger.info(f"{node} online.")
-            return True
+
         self.logger.error(f"{node} still offline.")
         return False
 
@@ -102,12 +93,8 @@ class MachineOps(AbstractOps):
         Arg:
             node (str)
         Returns:
-            bool value: True if node is online or False.
+            bool value: True if node is offline or False.
         """
-        status = self.check_node_power_status(node)
-        if not status[node]:
-            self.logger.info(f"{node} offline.")
-            return True
         iter_v = 0
         while iter_v < timeout:
             status = self.check_node_power_status(node)
@@ -116,10 +103,7 @@ class MachineOps(AbstractOps):
                 return True
             time.sleep(1)
             iter_v += 1
-        status = self.check_node_power_status(node)
-        if not status[node]:
-            self.logger.info(f"{node} offline.")
-            return True
+
         self.logger.error(f"{node} still online.")
         return False
 

--- a/tests/functional/glusterfind/test_gfind_delete_file.py
+++ b/tests/functional/glusterfind/test_gfind_delete_file.py
@@ -21,6 +21,7 @@
 
 # disruptive;dist,rep,dist-rep,disp,dist-disp
 import traceback
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -128,6 +129,9 @@ class TestGlusterFindDeletes(DParentTest):
         # Perform glusterfind pre for the session
         redant.gfind_pre(self.server_list[0], self.vol_name, self.session,
                          self.outfiles[1], debug=True)
+
+        # Wait for outfile to reflect changes
+        sleep(2)
 
         # Check if the outfile exists
         ret = redant.path_exists(self.server_list[0], self.outfiles[1])

--- a/tests/functional/glusterfind/test_gfind_delete_file.py
+++ b/tests/functional/glusterfind/test_gfind_delete_file.py
@@ -126,12 +126,12 @@ class TestGlusterFindDeletes(DParentTest):
             if ret:
                 raise Exception("Unexpected: File still exist")
 
+        # Wait for changelog to be updated
+        sleep(2)
+
         # Perform glusterfind pre for the session
         redant.gfind_pre(self.server_list[0], self.vol_name, self.session,
                          self.outfiles[1], debug=True)
-
-        # Wait for outfile to reflect changes
-        sleep(2)
 
         # Check if the outfile exists
         ret = redant.path_exists(self.server_list[0], self.outfiles[1])

--- a/tests/functional/glusterfind/test_gfind_modify_files.py
+++ b/tests/functional/glusterfind/test_gfind_modify_files.py
@@ -133,12 +133,12 @@ class TestGlusterFindModify(DParentTest):
             if ret != 0:
                 raise Exception("Pattern not found in file")
 
+        # Wait for changelog to be updated
+        sleep(2)
+
         # Perform glusterfind pre for the session
         redant.gfind_pre(self.server_list[0], self.vol_name, self.session,
                          self.outfiles[1], debug=True)
-
-        # Wait for changelog to get updated
-        sleep(2)
 
         # Check if the outfile exists
         ret = redant.path_exists(self.server_list[0], self.outfiles[1])

--- a/tests/functional/glusterfind/test_gfind_modify_files.py
+++ b/tests/functional/glusterfind/test_gfind_modify_files.py
@@ -133,12 +133,12 @@ class TestGlusterFindModify(DParentTest):
             if ret != 0:
                 raise Exception("Pattern not found in file")
 
-        # Wait for changelog to get updated
-        sleep(2)
-
         # Perform glusterfind pre for the session
         redant.gfind_pre(self.server_list[0], self.vol_name, self.session,
                          self.outfiles[1], debug=True)
+
+        # Wait for changelog to get updated
+        sleep(2)
 
         # Check if the outfile exists
         ret = redant.path_exists(self.server_list[0], self.outfiles[1])

--- a/tests/functional/glusterfind/test_gfind_rename.py
+++ b/tests/functional/glusterfind/test_gfind_rename.py
@@ -121,12 +121,12 @@ class TestGlusterFindRenames(DParentTest):
             if not ret:
                 raise Exception(f"Failed to rename file{i}")
 
+        # Wait for changelog to be updated
+        sleep(2)
+
         # Perform glusterfind pre for the session
         redant.gfind_pre(self.server_list[0], self.vol_name, self.session,
                          self.outfiles[1], debug=True)
-
-        # Wait for changelog to be updated
-        sleep(2)
 
         # Check if the outfile exists
         ret = redant.path_exists(self.server_list[0], self.outfiles[1])

--- a/tests/functional/glusterfind/test_gfind_rename.py
+++ b/tests/functional/glusterfind/test_gfind_rename.py
@@ -121,11 +121,12 @@ class TestGlusterFindRenames(DParentTest):
             if not ret:
                 raise Exception(f"Failed to rename file{i}")
 
-        sleep(2)
-
         # Perform glusterfind pre for the session
         redant.gfind_pre(self.server_list[0], self.vol_name, self.session,
                          self.outfiles[1], debug=True)
+
+        # Wait for changelog to be updated
+        sleep(2)
 
         # Check if the outfile exists
         ret = redant.path_exists(self.server_list[0], self.outfiles[1])

--- a/tests/functional/glusterfind/test_glusterfind_when_node_down.py
+++ b/tests/functional/glusterfind/test_glusterfind_when_node_down.py
@@ -1,0 +1,280 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY :or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+    Test Glusterfind when node is down
+"""
+
+from random import choice
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
+from glustolibs.gluster.lib_utils import list_files
+from glustolibs.gluster.glusterfile import (
+    file_exists,
+    remove_file,
+    check_if_pattern_in_file)
+from glustolibs.gluster.glusterfind_ops import (
+    gfind_create,
+    gfind_list,
+    gfind_pre,
+    gfind_post,
+    gfind_delete)
+from glustolibs.gluster.gluster_init import (
+    stop_glusterd,
+    start_glusterd,
+    wait_for_glusterd_to_start)
+from glustolibs.misc.misc_libs import (
+    reboot_nodes,
+    are_nodes_online)
+
+
+@runs_on([["replicated", "distributed-replicated", "dispersed",
+           "distributed", "distributed-dispersed"],
+          ["glusterfs"]])
+class TestGlusterFindNodeDown(GlusterBaseClass):
+    """
+    Test glusterfind operation when a node is down.
+    """
+
+    def setUp(self):
+        """
+        setup volume and mount volume
+        Initiate necessary variables
+        """
+
+        # calling GlusterBaseClass setUp
+        self.get_super_method(self, 'setUp')()
+
+        self.file_limit = 0
+
+        # Setup Volume and Mount Volume
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume %s" % self.volname)
+        g.log.info("Successful in Setup Volume %s", self.volname)
+        self.session = "test-session-%s" % self.volname
+        self.outfiles = [("/tmp/test-outfile-%s-%s.txt"
+                          % (self.volname, i))for i in range(0, 2)]
+
+        # Set the changelog rollover-time to 1 second
+        # This needs to be done in order for glusterfind to keep checking
+        # for changes in the mount point
+        option = {'changelog.rollover-time': '1'}
+        ret = set_volume_options(self.mnode, self.volname, option)
+        if not ret:
+            raise ExecutionError("Failed to set the volume option %s for %s"
+                                 % (option, self.volname))
+        g.log.info("Successfully set the volume option for the volume %s",
+                   self.volname)
+
+    def _perform_io_and_validate_presence_of_files(self):
+        """
+        Function to perform the IO and validate the presence of files.
+        """
+        self.file_limit += 10
+        # Starting IO on the mounts
+        cmd = ("cd %s ; touch file{%d..%d}" % (self.mounts[0].mountpoint,
+                                               self.file_limit-10,
+                                               self.file_limit))
+
+        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
+        self.assertEqual(ret, 0, "Failed to create files on mountpoint")
+        g.log.info("Files created successfully on mountpoint")
+
+        # Gather the list of files from the mount point
+        files = list_files(self.mounts[0].client_system,
+                           self.mounts[0].mountpoint)
+        self.assertIsNotNone(files, "Failed to get the list of files")
+        g.log.info("Successfully gathered the list of files from mount point")
+
+        # Check if the files exist
+        for filename in files:
+            ret = file_exists(self.mounts[0].client_system, filename)
+            self.assertTrue(ret, ("Unexpected: File '%s' does not exist"
+                                  % filename))
+            g.log.info("Successfully validated existence of '%s'", filename)
+
+    def _perform_glusterfind_pre_and_validate_outfile(self):
+        """
+        Function to perform glusterfind pre and validate outfile
+        """
+        # Perform glusterfind pre for the session
+        ret, _, _ = gfind_pre(self.mnode, self.volname, self.session,
+                              self.outfiles[0], full=True, noencode=True,
+                              debug=True)
+        self.assertEqual(ret, 0, ("Failed to perform glusterfind pre"))
+        g.log.info("Successfully performed glusterfind pre")
+
+        # Check if the outfile exists
+        ret = file_exists(self.mnode, self.outfiles[0])
+        self.assertTrue(ret, ("Unexpected: File '%s' does not exist"
+                              % self.outfiles[0]))
+        g.log.info("Successfully validated existence of '%s'",
+                   self.outfiles[0])
+
+        # Check if all the files are listed in the outfile
+        for i in range(1, self.file_limit+1):
+            ret = check_if_pattern_in_file(self.mnode, "file%s" % i,
+                                           self.outfiles[0])
+            self.assertEqual(ret, 0, ("File 'file%s' not listed in %s"
+                                      % (i, self.outfiles[0])))
+            g.log.info("File 'file%s' listed in %s", i, self.outfiles[0])
+
+    def test_gfind_when_node_down(self):
+        """
+        Verifying the glusterfind functionality when node is down.
+
+        1. Create a volume
+        2. Create a session on the volume
+        3. Create various files from mount point
+        4. Bring down glusterd on one of the node
+        5. Perform glusterfind pre
+        6. Perform glusterfind post
+        7. Check the contents of outfile
+        8. Create more files from mountpoint
+        9. Reboot one of the nodes
+        10. Perform gluserfind pre
+        11. Perform glusterfind post
+        12. Check the contents of outfile
+        """
+
+        # pylint: disable=too-many-statements
+        # Create a session for the volume
+        ret, _, _ = gfind_create(self.mnode, self.volname, self.session)
+        self.assertEqual(ret, 0, ("Unexpected: Creation of a session for the "
+                                  "volume %s failed" % self.volname))
+        g.log.info("Successfully created a session for the volume %s",
+                   self.volname)
+
+        # Perform glusterfind list to check if session exists
+        _, out, _ = gfind_list(self.mnode, volname=self.volname,
+                               sessname=self.session)
+        self.assertNotEqual(out, "No sessions found.",
+                            "Failed to list the glusterfind session")
+        g.log.info("Successfully listed the glusterfind session")
+
+        self._perform_io_and_validate_presence_of_files()
+
+        # Wait for changelog to get updated
+        sleep(2)
+
+        # Bring one of the node down.
+        self.random_server = choice(self.servers[1:])
+        ret = stop_glusterd(self.random_server)
+        self.assertTrue(ret, "Failed to stop glusterd on one node.")
+        g.log.info("Succesfully stopped glusterd on one node.")
+
+        self._perform_glusterfind_pre_and_validate_outfile()
+
+        # Perform glusterfind post for the session
+        ret, _, _ = gfind_post(self.mnode, self.volname, self.session)
+        self.assertEqual(ret, 0, ("Failed to perform glusterfind post"))
+        g.log.info("Successfully performed glusterfind post")
+
+        # Bring glusterd which was downed on a random node, up.
+        ret = start_glusterd(self.random_server)
+        self.assertTrue(ret, "Failed to start glusterd on %s"
+                        % self.random_server)
+        g.log.info("Successfully started glusterd on node : %s",
+                   self.random_server)
+
+        # Waiting for glusterd to start completely.
+        ret = wait_for_glusterd_to_start(self.random_server)
+        self.assertTrue(ret, "glusterd is not running on %s"
+                        % self.random_server)
+        g.log.info("glusterd is started and running on %s",
+                   self.random_server)
+
+        self._perform_io_and_validate_presence_of_files()
+
+        # Perform IO
+        self._perform_io_and_validate_presence_of_files()
+
+        # Wait for changelog to get updated
+        sleep(2)
+
+        # Reboot one of the nodes.
+        self.random_server = choice(self.servers[1:])
+        ret = reboot_nodes(self.random_server)
+        self.assertTrue(ret, "Failed to reboot the said node.")
+        g.log.info("Successfully started reboot process on one node.")
+
+        self._perform_glusterfind_pre_and_validate_outfile()
+
+        # Perform glusterfind post for the session
+        ret, _, _ = gfind_post(self.mnode, self.volname, self.session)
+        self.assertEqual(ret, 0, ("Failed to perform glusterfind post"))
+        g.log.info("Successfully performed glusterfind post")
+
+        # Gradual sleep backoff till the node has rebooted.
+        counter = 0
+        timeout = 300
+        ret = False
+        while counter < timeout:
+            ret, _ = are_nodes_online(self.random_server)
+            if not ret:
+                g.log.info("Node's offline, Retrying after 5 seconds ...")
+                sleep(5)
+                counter += 5
+            else:
+                ret = True
+                break
+        self.assertTrue(ret, "Node is still offline.")
+        g.log.info("Rebooted node is online")
+
+        # Wait for glusterd to start completely
+        ret = wait_for_glusterd_to_start(self.random_server)
+        self.assertTrue(ret, "glusterd is not running on %s"
+                        % self.random_server)
+        g.log.info("glusterd is started and running on %s",
+                   self.random_server)
+
+    def tearDown(self):
+        """
+        tearDown for every test
+        Clean up and unmount the volume
+        """
+        # calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()
+
+        # Delete the glusterfind sessions
+        ret, _, _ = gfind_delete(self.mnode, self.volname, self.session)
+        if ret:
+            raise ExecutionError("Failed to delete session %s" % self.session)
+        g.log.info("Successfully deleted session %s", self.session)
+
+        # Remove the outfiles created during 'glusterfind pre'
+        for out in self.outfiles:
+            ret = remove_file(self.mnode, out, force=True)
+            if not ret:
+                raise ExecutionError("Failed to remove the outfile %s" % out)
+        g.log.info("Successfully removed the outfiles")
+
+        # Wait for the peers to be connected.
+        ret = wait_for_peers_to_connect(self.mnode, self.servers, 100)
+        if not ret:
+            raise ExecutionError("Peers are not in connected state.")
+
+        # Cleanup the volume
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Cleanup Volume")
+        g.log.info("Successful in Cleanup Volume")

--- a/tests/functional/glusterfind/test_glusterfind_when_node_down.py
+++ b/tests/functional/glusterfind/test_glusterfind_when_node_down.py
@@ -1,90 +1,51 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY :or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-Description:
+ Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY :or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
     Test Glusterfind when node is down
 """
 
+# disruptive;dist,rep,dist-rep,disp,dist-disp
+import traceback
 from random import choice
 from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import set_volume_options
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
-from glustolibs.gluster.lib_utils import list_files
-from glustolibs.gluster.glusterfile import (
-    file_exists,
-    remove_file,
-    check_if_pattern_in_file)
-from glustolibs.gluster.glusterfind_ops import (
-    gfind_create,
-    gfind_list,
-    gfind_pre,
-    gfind_post,
-    gfind_delete)
-from glustolibs.gluster.gluster_init import (
-    stop_glusterd,
-    start_glusterd,
-    is_glusterd_running,
-    wait_for_glusterd_to_start)
-from glustolibs.misc.misc_libs import (
-    reboot_nodes,
-    are_nodes_online)
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([["replicated", "distributed-replicated", "dispersed",
-           "distributed", "distributed-dispersed"],
-          ["glusterfs"]])
-class TestGlusterFindNodeDown(GlusterBaseClass):
-    """
-    Test glusterfind operation when a node is down.
-    """
+class TestGlusterFindNodeDown(DParentTest):
 
-    def setUp(self):
+    def terminate(self):
         """
-        setup volume and mount volume
-        Initiate necessary variables
+        Delete glusterfind session and cleanup outfiles
         """
+        try:
+            self.redant.gfind_delete(self.server_list[0], self.vol_name,
+                                     self.session)
+            ret = self.redant.remove_file(self.server_list[0], self.outfile,
+                                          True)
+            if not ret:
+                raise Exception("Failed to remove the outfile "
+                                f"{self.outfile}")
 
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        self.file_limit = 0
-
-        # Setup Volume and Mount Volume
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume %s" % self.volname)
-        g.log.info("Successful in Setup Volume %s", self.volname)
-        self.session = "test-session-%s" % self.volname
-        self.outfiles = [("/tmp/test-outfile-%s-%s.txt"
-                          % (self.volname, i))for i in range(0, 2)]
-
-        # Set the changelog rollover-time to 1 second
-        # This needs to be done in order for glusterfind to keep checking
-        # for changes in the mount point
-        option = {'changelog.rollover-time': '1'}
-        ret = set_volume_options(self.mnode, self.volname, option)
-        if not ret:
-            raise ExecutionError("Failed to set the volume option %s for %s"
-                                 % (option, self.volname))
-        g.log.info("Successfully set the volume option for the volume %s",
-                   self.volname)
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
     def _perform_io_and_validate_presence_of_files(self):
         """
@@ -92,54 +53,51 @@ class TestGlusterFindNodeDown(GlusterBaseClass):
         """
         self.file_limit += 10
         # Starting IO on the mounts
-        cmd = ("cd %s ; touch file{%d..%d}" % (self.mounts[0].mountpoint,
-                                               self.file_limit-10,
-                                               self.file_limit))
+        cmd = (f"cd {self.mountpoint};"
+               "touch file{"
+               f"{self.file_limit - 10}..{self.file_limit}"
+               "}")
 
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Failed to create files on mountpoint")
-        g.log.info("Files created successfully on mountpoint")
+        self.redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Gather the list of files from the mount point
-        files = list_files(self.mounts[0].client_system,
-                           self.mounts[0].mountpoint)
-        self.assertIsNotNone(files, "Failed to get the list of files")
-        g.log.info("Successfully gathered the list of files from mount point")
+        files = self.redant.list_files(self.client_list[0], self.mountpoint)
+        if files is None:
+            raise Exception("Failed to get the list of files")
 
         # Check if the files exist
         for filename in files:
-            ret = file_exists(self.mounts[0].client_system, filename)
-            self.assertTrue(ret, ("Unexpected: File '%s' does not exist"
-                                  % filename))
-            g.log.info("Successfully validated existence of '%s'", filename)
+            file = filename.rstrip('\n')
+            ret = self.redant.path_exists(self.client_list[0],
+                                          file)
+            if not ret:
+                raise Exception(f"Unexpected: File {file} does not exist")
 
     def _perform_glusterfind_pre_and_validate_outfile(self):
         """
         Function to perform glusterfind pre and validate outfile
         """
         # Perform glusterfind pre for the session
-        ret, _, _ = gfind_pre(self.mnode, self.volname, self.session,
-                              self.outfiles[0], full=True, noencode=True,
-                              debug=True)
-        self.assertEqual(ret, 0, ("Failed to perform glusterfind pre"))
-        g.log.info("Successfully performed glusterfind pre")
+        self.redant.gfind_pre(self.server_list[0], self.vol_name,
+                              self.session, self.outfile, full=True,
+                              noencode=True, debug=True)
 
         # Check if the outfile exists
-        ret = file_exists(self.mnode, self.outfiles[0])
-        self.assertTrue(ret, ("Unexpected: File '%s' does not exist"
-                              % self.outfiles[0]))
-        g.log.info("Successfully validated existence of '%s'",
-                   self.outfiles[0])
+        ret = self.redant.path_exists(self.server_list[0], self.outfile)
+        if not ret:
+            raise Exception(f"Unexpected: File {self.outfile} does not"
+                            " exist")
 
         # Check if all the files are listed in the outfile
         for i in range(1, self.file_limit+1):
-            ret = check_if_pattern_in_file(self.mnode, "file%s" % i,
-                                           self.outfiles[0])
-            self.assertEqual(ret, 0, ("File 'file%s' not listed in %s"
-                                      % (i, self.outfiles[0])))
-            g.log.info("File 'file%s' listed in %s", i, self.outfiles[0])
+            pattern = f"file{i}"
+            ret = self.redant.check_if_pattern_in_file(self.server_list[0],
+                                                       pattern, self.outfile)
+            if ret != 0:
+                raise Exception(f"File file{i} not listed in "
+                                f"{self.outfile}")
 
-    def test_gfind_when_node_down(self):
+    def run_test(self, redant):
         """
         Verifying the glusterfind functionality when node is down.
 
@@ -156,21 +114,19 @@ class TestGlusterFindNodeDown(GlusterBaseClass):
         11. Perform glusterfind post
         12. Check the contents of outfile
         """
+        self.file_limit = 0
+        self.session = f'test-session-{self.vol_name}'
+        self.outfile = f"/tmp/test-outfile-{self.vol_name}.txt"
 
-        # pylint: disable=too-many-statements
-        # Create a session for the volume
-        ret, _, _ = gfind_create(self.mnode, self.volname, self.session)
-        self.assertEqual(ret, 0, ("Unexpected: Creation of a session for the "
-                                  "volume %s failed" % self.volname))
-        g.log.info("Successfully created a session for the volume %s",
-                   self.volname)
+        # Set the changelog rollover-time to 1 second
+        option = {'changelog.rollover-time': '1'}
+        redant.set_volume_options(self.vol_name, option, self.server_list[0])
+
+        # Creating a session for the volume
+        redant.gfind_create(self.server_list[0], self.vol_name, self.session)
 
         # Perform glusterfind list to check if session exists
-        _, out, _ = gfind_list(self.mnode, volname=self.volname,
-                               sessname=self.session)
-        self.assertNotEqual(out, "No sessions found.",
-                            "Failed to list the glusterfind session")
-        g.log.info("Successfully listed the glusterfind session")
+        redant.gfind_list(self.server_list[0], self.vol_name, self.session)
 
         self._perform_io_and_validate_presence_of_files()
 
@@ -178,35 +134,24 @@ class TestGlusterFindNodeDown(GlusterBaseClass):
         sleep(2)
 
         # Bring one of the node down.
-        self.random_server = choice(self.servers[1:])
-        ret = stop_glusterd(self.random_server)
-        self.assertTrue(ret, "Failed to stop glusterd on one node.")
-        g.log.info("Succesfully stopped glusterd on one node.")
+        self.random_server = choice(self.server_list[1:])
+        redant.stop_glusterd(self.random_server)
 
         # Wait till glusterd is completely down.
-        while is_glusterd_running(self.random_server) != 1:
-            sleep(2)
+        if not redant.wait_for_glusterd_to_stop(self.random_server):
+            raise Exception("Failed to stop glusterd")
 
         self._perform_glusterfind_pre_and_validate_outfile()
 
         # Perform glusterfind post for the session
-        ret, _, _ = gfind_post(self.mnode, self.volname, self.session)
-        self.assertEqual(ret, 0, ("Failed to perform glusterfind post"))
-        g.log.info("Successfully performed glusterfind post")
+        redant.gfind_post(self.server_list[0], self.vol_name, self.session)
 
         # Bring glusterd which was downed on a random node, up.
-        ret = start_glusterd(self.random_server)
-        self.assertTrue(ret, "Failed to start glusterd on %s"
-                        % self.random_server)
-        g.log.info("Successfully started glusterd on node : %s",
-                   self.random_server)
+        redant.start_glusterd(self.random_server)
 
         # Waiting for glusterd to start completely.
-        ret = wait_for_glusterd_to_start(self.random_server)
-        self.assertTrue(ret, "glusterd is not running on %s"
-                        % self.random_server)
-        g.log.info("glusterd is started and running on %s",
-                   self.random_server)
+        if not redant.wait_for_glusterd_to_start(self.random_server):
+            raise Exception("Failed to start glusterd")
 
         self._perform_io_and_validate_presence_of_files()
 
@@ -217,69 +162,30 @@ class TestGlusterFindNodeDown(GlusterBaseClass):
         sleep(2)
 
         # Reboot one of the nodes.
-        self.random_server = choice(self.servers[1:])
-        ret = reboot_nodes(self.random_server)
-        self.assertTrue(ret, "Failed to reboot the said node.")
-        g.log.info("Successfully started reboot process on one node.")
+        self.random_server = choice(self.server_list[1:])
+        redant.reboot_nodes(self.random_server)
 
         self._perform_glusterfind_pre_and_validate_outfile()
 
         # Perform glusterfind post for the session
-        ret, _, _ = gfind_post(self.mnode, self.volname, self.session)
-        self.assertEqual(ret, 0, ("Failed to perform glusterfind post"))
-        g.log.info("Successfully performed glusterfind post")
+        redant.gfind_post(self.server_list[0], self.vol_name, self.session)
 
         # Gradual sleep backoff till the node has rebooted.
         counter = 0
         timeout = 300
         ret = False
         while counter < timeout:
-            ret, _ = are_nodes_online(self.random_server)
+            ret = redant.are_nodes_online(self.random_server)
             if not ret:
-                g.log.info("Node's offline, Retrying after 5 seconds ...")
+                self.logger.info("Node's offline, Retrying after 5 seconds..")
                 sleep(5)
                 counter += 5
             else:
                 ret = True
                 break
-        self.assertTrue(ret, "Node is still offline.")
-        g.log.info("Rebooted node is online")
+        if not ret:
+            raise Exception("Node is still offline")
 
         # Wait for glusterd to start completely
-        ret = wait_for_glusterd_to_start(self.random_server)
-        self.assertTrue(ret, "glusterd is not running on %s"
-                        % self.random_server)
-        g.log.info("glusterd is started and running on %s",
-                   self.random_server)
-
-    def tearDown(self):
-        """
-        tearDown for every test
-        Clean up and unmount the volume
-        """
-        # calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-        # Delete the glusterfind sessions
-        ret, _, _ = gfind_delete(self.mnode, self.volname, self.session)
-        if ret:
-            raise ExecutionError("Failed to delete session %s" % self.session)
-        g.log.info("Successfully deleted session %s", self.session)
-
-        # Remove the outfiles created during 'glusterfind pre'
-        for out in self.outfiles:
-            ret = remove_file(self.mnode, out, force=True)
-            if not ret:
-                raise ExecutionError("Failed to remove the outfile %s" % out)
-        g.log.info("Successfully removed the outfiles")
-
-        # Wait for the peers to be connected.
-        ret = wait_for_peers_to_connect(self.mnode, self.servers, 100)
-        if not ret:
-            raise ExecutionError("Peers are not in connected state.")
-
-        # Cleanup the volume
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Cleanup Volume")
-        g.log.info("Successful in Cleanup Volume")
+        if not redant.wait_for_glusterd_to_start(self.random_server):
+            raise Exception("Glusterd failed to start after node reboot")

--- a/tests/functional/glusterfind/test_glusterfind_when_node_down.py
+++ b/tests/functional/glusterfind/test_glusterfind_when_node_down.py
@@ -40,6 +40,7 @@ from glustolibs.gluster.glusterfind_ops import (
 from glustolibs.gluster.gluster_init import (
     stop_glusterd,
     start_glusterd,
+    is_glusterd_running,
     wait_for_glusterd_to_start)
 from glustolibs.misc.misc_libs import (
     reboot_nodes,
@@ -181,6 +182,10 @@ class TestGlusterFindNodeDown(GlusterBaseClass):
         ret = stop_glusterd(self.random_server)
         self.assertTrue(ret, "Failed to stop glusterd on one node.")
         g.log.info("Succesfully stopped glusterd on one node.")
+
+        # Wait till glusterd is completely down.
+        while is_glusterd_running(self.random_server) != 1:
+            sleep(2)
 
         self._perform_glusterfind_pre_and_validate_outfile()
 


### PR DESCRIPTION
Migrated TC [test_glusterfind_when_node_down](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterfind/test_glusterfind_when_node_down.py)

Also, updated other TCs to add a sleep after pre-operation in case of file changes, as the changelog sometimes takes a bit of time to reflect the changes in the outfile.

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>