### PR TITLE
Migrated test_healed_and_heal_failed_command

### DIFF
--- a/common/ops/gluster_ops/heal_ops.py
+++ b/common/ops/gluster_ops/heal_ops.py
@@ -596,14 +596,19 @@ class HealOps:
 
         return True
 
-    def heal_info_heal_failed(self, volname: str, node: str) -> dict:
+    def heal_info_heal_failed(self, volname: str, node: str,
+                              excep: bool = True) -> dict:
         """Get entries on which heal failed for the volume by executing:
             'gluster volume heal <volname> info heal-failed'
 
         Args:
             volname (str): Name of the volume
             node (str): Node on which commands are executed.
-
+        Optional:
+        excep (bool): exception flag to bypass the exception if the
+                      cmd fails. If set to False the exception is
+                      bypassed and value from remote executioner is
+                      returned. Defaults to True
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -614,7 +619,7 @@ class HealOps:
                 - node : node on which the command got executed
         """
         cmd = f"gluster volume heal {volname} info heal-failed"
-        return self.execute_abstract_op_node(cmd, node)
+        return self.execute_abstract_op_node(cmd, node, excep)
 
     def heal_info_healed(self, volname: str, node: str,
                          excep: bool = True) -> dict:

--- a/common/ops/gluster_ops/heal_ops.py
+++ b/common/ops/gluster_ops/heal_ops.py
@@ -616,7 +616,8 @@ class HealOps:
         cmd = f"gluster volume heal {volname} info heal-failed"
         return self.execute_abstract_op_node(cmd, node)
 
-    def heal_info_healed(self, volname: str, node: str) -> dict:
+    def heal_info_healed(self, volname: str, node: str,
+                         excep: bool = True) -> dict:
         """
         Get healed entries information for the volume by executing:
         'gluster volume heal <volname> info healed'
@@ -624,7 +625,11 @@ class HealOps:
         Args:
             volname (str): Name of the volume
             node (str): Node on which commands are executed.
-
+        Optional:
+        excep (bool): exception flag to bypass the exception if the
+                      cmd fails. If set to False the exception is
+                      bypassed and value from remote executioner is
+                      returned. Defaults to True
         Returns:
         ret: A dictionary consisting
             - Flag : Flag to check if connection failed
@@ -635,7 +640,7 @@ class HealOps:
             - node : node on which the command got executed
         """
         cmd = f"gluster volume heal {volname} info healed"
-        return self.execute_abstract_op_node(cmd, node)
+        return self.execute_abstract_op_node(cmd, node, excep)
 
     def enable_granular_heal(self, volname: str, node: str) -> bool:
         """Enable granular heal on a given volume

--- a/tests/functional/afr/test_healed_and_heal_failed_command.py
+++ b/tests/functional/afr/test_healed_and_heal_failed_command.py
@@ -83,10 +83,19 @@ class TestCase(DParentTest):
         ret = redant.heal_info_healed(self.vol_name, self.server_list[0],
                                       False)
         if ret['error_code'] == 0:
-            raise Exception(f"{cmd} heal-failed should result in error.")
+            raise Exception(f"`{cmd} healed` should result in error.")
 
         if 'Usage' not in ret['error_msg']:
-            raise Exception(f"{cmd} heal-failed should list 'Usage'")
+            raise Exception(f"`{cmd} healed` should list 'Usage'")
+
+        # Verify `gluster volume heal <volname> info heal-failed` errors out
+        ret = redant.heal_info_heal_failed(self.vol_name, self.server_list[0],
+                                           False)
+        if ret['error_code'] == 0:
+            raise Exception(f"`{cmd} heal-failed` should result in error.")
+
+        if 'Usage' not in ret['error_msg']:
+            raise Exception(f"`{cmd} heal-failed` should list 'Usage'")
 
         # Verify absence of `healed` nd `heal-failed` commands in `volume help`
         cmd = 'gluster volume help | grep -i heal'

--- a/tests/functional/afr/test_healed_and_heal_failed_command.py
+++ b/tests/functional/afr/test_healed_and_heal_failed_command.py
@@ -44,7 +44,6 @@ class TestCase(DParentTest):
 
     def run_test(self, redant):
         """
-
         Steps:
         - Create and mount a replicated volume
         - Kill one of the bricks and write IO from mount point

--- a/tests/functional/afr/test_healed_and_heal_failed_command.py
+++ b/tests/functional/afr/test_healed_and_heal_failed_command.py
@@ -1,0 +1,104 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from random import choice
+
+from glusto.core import Glusto as g
+
+from glustolibs.gluster.brick_libs import (bring_bricks_offline,
+                                           get_online_bricks_list)
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.heal_ops import heal_info_heal_failed, heal_info_healed
+from glustolibs.misc.misc_libs import upload_scripts
+
+
+@runs_on([['replicated'], ['glusterfs', 'nfs']])
+class TestHealedAndHealFailedCommand(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        cls.get_super_method(cls, 'setUpClass')()
+        cls.script_path = '/usr/share/glustolibs/io/scripts/file_dir_ops.py'
+        if not upload_scripts(cls.clients, cls.script_path):
+            raise ExecutionError('Failed to upload IO scripts to client')
+
+    def setUp(self):
+        self.get_super_method(self, 'setUp')()
+        self.mounts = [self.mounts[0]]
+        if not self.setup_volume_and_mount_volume(mounts=self.mounts):
+            raise ExecutionError('Failed to setup and mount '
+                                 '{}'.format(self.volname))
+
+    def tearDown(self):
+        if not self.unmount_volume_and_cleanup_volume(mounts=self.mounts):
+            raise ExecutionError('Not able to unmount and cleanup '
+                                 '{}'.format(self.volname))
+        self.get_super_method(self, 'tearDown')()
+
+    def test_healed_and_heal_failed_command(self):
+        """
+        Description: Validate absence of `healed` and `heal-failed` options
+
+        Steps:
+        - Create and mount a replicated volume
+        - Kill one of the bricks and write IO from mount point
+        - Verify `gluster volume heal <volname> info healed` and `gluster
+          volume heal <volname> info heal-failed` command results in error
+        - Validate `gluster volume help` doesn't list `healed` and
+          `heal-failed` commands
+        """
+
+        client, m_point = (self.mounts[0].client_system,
+                           self.mounts[0].mountpoint)
+
+        # Kill one of the bricks in the volume
+        brick_list = get_online_bricks_list(self.mnode, self.volname)
+        self.assertIsNotNone(brick_list, 'Unable to get online bricks list')
+        ret = bring_bricks_offline(self.volname, choice(brick_list))
+        self.assertTrue(ret, 'Unable to kill one of the bricks in the volume')
+
+        # Fill IO in the mount point
+        cmd = ('/usr/bin/env python {} '
+               'create_deep_dirs_with_files --dir-depth 10 '
+               '--fixed-file-size 1M --num-of-files 50 '
+               '--dirname-start-num 1 {}'.format(self.script_path, m_point))
+        ret, _, _ = g.run(client, cmd)
+        self.assertEqual(ret, 0, 'Not able to fill directory with IO')
+
+        # Verify `gluster volume heal <volname> info healed` results in error
+        cmd = 'gluster volume heal <volname> info'
+        ret, _, err = heal_info_healed(self.mnode, self.volname)
+        self.assertNotEqual(ret, 0, '`%s healed` should result in error' % cmd)
+        self.assertIn('Usage', err, '`%s healed` should list `Usage`' % cmd)
+
+        # Verify `gluster volume heal <volname> info heal-failed` errors out
+        ret, _, err = heal_info_heal_failed(self.mnode, self.volname)
+        self.assertNotEqual(ret, 0,
+                            '`%s heal-failed` should result in error' % cmd)
+        self.assertIn('Usage', err,
+                      '`%s heal-failed` should list `Usage`' % cmd)
+
+        # Verify absence of `healed` nd `heal-failed` commands in `volume help`
+        cmd = 'gluster volume help | grep -i heal'
+        ret, rout, _ = g.run(self.mnode, cmd)
+        self.assertEqual(
+            ret, 0, 'Unable to query help content from `gluster volume help`')
+        self.assertNotIn(
+            'healed', rout, '`healed` string should not exist '
+            'in `gluster volume help` command')
+        self.assertNotIn(
+            'heal-failed', rout, '`heal-failed` string should '
+            'not exist in `gluster volume help` command')

--- a/tests/functional/afr/test_healed_and_heal_failed_command.py
+++ b/tests/functional/afr/test_healed_and_heal_failed_command.py
@@ -15,20 +15,20 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-@runs_on([['replicated'], ['glusterfs', 'nfs']])
+Description:
+    Validate absence of `healed` and `heal-failed` options
 """
 
 # disruptive;rep
 # TODO: nfs
 
-# from random import choice
+from random import choice
 from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
     
     def run_test(self, redant):
         """
-        Description: Validate absence of `healed` and `heal-failed` options
 
         Steps:
         - Create and mount a replicated volume
@@ -42,11 +42,17 @@ class TestCase(DParentTest):
         # client, m_point = (self.mounts[0].client_system,
         #                    self.mounts[0].mountpoint)
 
-        # # Kill one of the bricks in the volume
-        # brick_list = get_online_bricks_list(self.mnode, self.volname)
-        # self.assertIsNotNone(brick_list, 'Unable to get online bricks list')
-        # ret = bring_bricks_offline(self.volname, choice(brick_list))
-        # self.assertTrue(ret, 'Unable to kill one of the bricks in the volume')
+        # Kill one of the bricks in the volume
+        bricks_list = redant.get_online_bricks_list(self.vol_name,
+                                                    self.server_list[0])
+        if bricks_list is None:
+            raise Exception("Unable to get the bricks list")
+
+        random_brick = choice(bricks_list)
+        redant.bring_bricks_offline(self.vol_name, random_brick)
+        if not redant.are_bricks_offline(self.vol_name, [random_brick],
+                                         self.server_list[0]):
+            raise Exception(f"Brick {random_brick} is not offline.")
 
         # # Fill IO in the mount point
         # cmd = ('/usr/bin/env python {} '

--- a/tests/functional/afr/test_healed_and_heal_failed_command.py
+++ b/tests/functional/afr/test_healed_and_heal_failed_command.py
@@ -1,54 +1,32 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
 
-from random import choice
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
 
-from glusto.core import Glusto as g
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-from glustolibs.gluster.brick_libs import (bring_bricks_offline,
-                                           get_online_bricks_list)
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.heal_ops import heal_info_heal_failed, heal_info_healed
-from glustolibs.misc.misc_libs import upload_scripts
-
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 @runs_on([['replicated'], ['glusterfs', 'nfs']])
-class TestHealedAndHealFailedCommand(GlusterBaseClass):
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-        cls.script_path = '/usr/share/glustolibs/io/scripts/file_dir_ops.py'
-        if not upload_scripts(cls.clients, cls.script_path):
-            raise ExecutionError('Failed to upload IO scripts to client')
+"""
 
-    def setUp(self):
-        self.get_super_method(self, 'setUp')()
-        self.mounts = [self.mounts[0]]
-        if not self.setup_volume_and_mount_volume(mounts=self.mounts):
-            raise ExecutionError('Failed to setup and mount '
-                                 '{}'.format(self.volname))
+# disruptive;rep
+# TODO: nfs
 
-    def tearDown(self):
-        if not self.unmount_volume_and_cleanup_volume(mounts=self.mounts):
-            raise ExecutionError('Not able to unmount and cleanup '
-                                 '{}'.format(self.volname))
-        self.get_super_method(self, 'tearDown')()
+# from random import choice
+from tests.d_parent_test import DParentTest
 
-    def test_healed_and_heal_failed_command(self):
+class TestCase(DParentTest):
+    
+    def run_test(self, redant):
         """
         Description: Validate absence of `healed` and `heal-failed` options
 
@@ -61,44 +39,44 @@ class TestHealedAndHealFailedCommand(GlusterBaseClass):
           `heal-failed` commands
         """
 
-        client, m_point = (self.mounts[0].client_system,
-                           self.mounts[0].mountpoint)
+        # client, m_point = (self.mounts[0].client_system,
+        #                    self.mounts[0].mountpoint)
 
-        # Kill one of the bricks in the volume
-        brick_list = get_online_bricks_list(self.mnode, self.volname)
-        self.assertIsNotNone(brick_list, 'Unable to get online bricks list')
-        ret = bring_bricks_offline(self.volname, choice(brick_list))
-        self.assertTrue(ret, 'Unable to kill one of the bricks in the volume')
+        # # Kill one of the bricks in the volume
+        # brick_list = get_online_bricks_list(self.mnode, self.volname)
+        # self.assertIsNotNone(brick_list, 'Unable to get online bricks list')
+        # ret = bring_bricks_offline(self.volname, choice(brick_list))
+        # self.assertTrue(ret, 'Unable to kill one of the bricks in the volume')
 
-        # Fill IO in the mount point
-        cmd = ('/usr/bin/env python {} '
-               'create_deep_dirs_with_files --dir-depth 10 '
-               '--fixed-file-size 1M --num-of-files 50 '
-               '--dirname-start-num 1 {}'.format(self.script_path, m_point))
-        ret, _, _ = g.run(client, cmd)
-        self.assertEqual(ret, 0, 'Not able to fill directory with IO')
+        # # Fill IO in the mount point
+        # cmd = ('/usr/bin/env python {} '
+        #        'create_deep_dirs_with_files --dir-depth 10 '
+        #        '--fixed-file-size 1M --num-of-files 50 '
+        #        '--dirname-start-num 1 {}'.format(self.script_path, m_point))
+        # ret, _, _ = g.run(client, cmd)
+        # self.assertEqual(ret, 0, 'Not able to fill directory with IO')
 
-        # Verify `gluster volume heal <volname> info healed` results in error
-        cmd = 'gluster volume heal <volname> info'
-        ret, _, err = heal_info_healed(self.mnode, self.volname)
-        self.assertNotEqual(ret, 0, '`%s healed` should result in error' % cmd)
-        self.assertIn('Usage', err, '`%s healed` should list `Usage`' % cmd)
+        # # Verify `gluster volume heal <volname> info healed` results in error
+        # cmd = 'gluster volume heal <volname> info'
+        # ret, _, err = heal_info_healed(self.mnode, self.volname)
+        # self.assertNotEqual(ret, 0, '`%s healed` should result in error' % cmd)
+        # self.assertIn('Usage', err, '`%s healed` should list `Usage`' % cmd)
 
-        # Verify `gluster volume heal <volname> info heal-failed` errors out
-        ret, _, err = heal_info_heal_failed(self.mnode, self.volname)
-        self.assertNotEqual(ret, 0,
-                            '`%s heal-failed` should result in error' % cmd)
-        self.assertIn('Usage', err,
-                      '`%s heal-failed` should list `Usage`' % cmd)
+        # # Verify `gluster volume heal <volname> info heal-failed` errors out
+        # ret, _, err = heal_info_heal_failed(self.mnode, self.volname)
+        # self.assertNotEqual(ret, 0,
+        #                     '`%s heal-failed` should result in error' % cmd)
+        # self.assertIn('Usage', err,
+        #               '`%s heal-failed` should list `Usage`' % cmd)
 
-        # Verify absence of `healed` nd `heal-failed` commands in `volume help`
-        cmd = 'gluster volume help | grep -i heal'
-        ret, rout, _ = g.run(self.mnode, cmd)
-        self.assertEqual(
-            ret, 0, 'Unable to query help content from `gluster volume help`')
-        self.assertNotIn(
-            'healed', rout, '`healed` string should not exist '
-            'in `gluster volume help` command')
-        self.assertNotIn(
-            'heal-failed', rout, '`heal-failed` string should '
-            'not exist in `gluster volume help` command')
+        # # Verify absence of `healed` nd `heal-failed` commands in `volume help`
+        # cmd = 'gluster volume help | grep -i heal'
+        # ret, rout, _ = g.run(self.mnode, cmd)
+        # self.assertEqual(
+        #     ret, 0, 'Unable to query help content from `gluster volume help`')
+        # self.assertNotIn(
+        #     'healed', rout, '`healed` string should not exist '
+        #     'in `gluster volume help` command')
+        # self.assertNotIn(
+        #     'heal-failed', rout, '`heal-failed` string should '
+        #     'not exist in `gluster volume help` command')


### PR DESCRIPTION
Migrated
[test_healed_and_heal_failed_command](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/afr/test_healed_and_heal_failed_command.py)

Updates: #292

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>