### PR TITLE
Migrated TC test_auth_allow

### DIFF
--- a/common/ops/gluster_ops/auth_ops.py
+++ b/common/ops/gluster_ops/auth_ops.py
@@ -310,13 +310,13 @@ class AuthOps(AbstractOps):
         ret = self.execute_abstract_op_node(cmd, client)
 
         # Command to fetch latest AUTH_FAILED event log message.
-        out = ret['msg'].rstrip('\n')
+        out = ret['msg'][0].rstrip('\n')
         cmd = f"grep AUTH_FAILED /var/log/glusterfs/{out} | tail -1"
         ret = self.execute_abstract_op_node(cmd, client)
 
         # Check whether the AUTH_FAILED log is of the latest mount failure
-        if ret['msg'].rstrip('\n') != previous_log_statement:
+        if ret['msg'][0].rstrip('\n') == previous_log_statement:
             raise Exception("Mount failure is not due to authentication "
                             "error")
 
-        return ret['msg'].rstrip('\n')
+        return ret['msg'][0].rstrip('\n')

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -73,11 +73,10 @@ class DParentTest(metaclass=abc.ABCMeta):
             self.setup_test()
 
             if not self.setup_done and self.volume_type != "Generic":
-                self.redant.volume_create(
-                    self.vol_name, self.server_list[0],
-                    self.vol_type_inf[self.volume_type],
-                    self.server_list, self.brick_roots, True)
-                self.redant.volume_start(self.vol_name, self.server_list[0])
+                self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                         self.vol_type_inf[self.volume_type],
+                                         self.server_list, self.brick_roots,
+                                         force=True)
                 self.mountpoint = (f"/mnt/{self.vol_name}")
                 for client in self.client_list:
                     self.redant.execute_abstract_op_node(f"mkdir -p "

--- a/tests/functional/authentication/test_auth_allow.py
+++ b/tests/functional/authentication/test_auth_allow.py
@@ -36,7 +36,7 @@ class FuseAuthAllow(GlusterBaseClass):
         """
         Create and start volume
         """
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         # Create and start volume
         g.log.info("Starting volume setup process %s", cls.volname)
         ret = cls.setup_volume()

--- a/tests/functional/authentication/test_auth_allow.py
+++ b/tests/functional/authentication/test_auth_allow.py
@@ -25,8 +25,7 @@ from glustolibs.gluster.auth_ops import set_auth_allow
 
 
 @runs_on([['replicated', 'distributed', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'],
-          ['glusterfs']])
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
 class FuseAuthAllow(GlusterBaseClass):
     """
     Tests to verify auth.allow feature on fuse mount.
@@ -38,13 +37,10 @@ class FuseAuthAllow(GlusterBaseClass):
         """
         cls.get_super_method(cls, 'setUpClass')()
         # Create and start volume
-        g.log.info("Starting volume setup process %s", cls.volname)
         ret = cls.setup_volume()
         if not ret:
             raise ExecutionError("Failed to setup "
                                  "and start volume %s" % cls.volname)
-        g.log.info("Successfully created and started the volume: %s",
-                   cls.volname)
 
     def authenticated_mount(self, mount_obj):
         """
@@ -147,7 +143,6 @@ class FuseAuthAllow(GlusterBaseClass):
         auth_dict = {'all': [self.mounts[0].client_system]}
         ret = set_auth_allow(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set authentication")
-        g.log.info("Successfully set authentication on volume")
 
         # Mounting volume on client1
         self.authenticated_mount(self.mounts[0])
@@ -179,7 +174,6 @@ class FuseAuthAllow(GlusterBaseClass):
         auth_dict = {'all': [hostname_client1.strip()]}
         ret = set_auth_allow(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set authentication")
-        g.log.info("Successfully set authentication on volume")
 
         # Mounting volume on client1
         self.authenticated_mount(self.mounts[0])
@@ -204,8 +198,9 @@ class FuseAuthAllow(GlusterBaseClass):
         """
         Cleanup volume
         """
-        g.log.info("Cleaning up volume")
         ret = self.cleanup_volume()
         if not ret:
             raise ExecutionError("Failed to cleanup volume.")
-        g.log.info("Volume cleanup was successful.")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/authentication/test_auth_allow.py
+++ b/tests/functional/authentication/test_auth_allow.py
@@ -1,131 +1,42 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-""" Description:
-        Test cases in this module tests the authentication allow feature
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
-                                                   runs_on)
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.auth_ops import set_auth_allow
+ Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    Test cases in this module tests the authentication allow feature
+"""
+
+# disruptive;dist,rep,dist-rep,disp,dist-disp
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'], ['glusterfs']])
-class FuseAuthAllow(GlusterBaseClass):
-    """
-    Tests to verify auth.allow feature on fuse mount.
-    """
-    @classmethod
-    def setUpClass(cls):
+class TestFuseAuthAllow(DParentTest):
+
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
         """
-        Create and start volume
+        Create and start the volume
         """
-        cls.get_super_method(cls, 'setUpClass')()
-        # Create and start volume
-        ret = cls.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup "
-                                 "and start volume %s" % cls.volname)
+        conf_hash = self.vol_type_inf[self.volume_type]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
 
-    def authenticated_mount(self, mount_obj):
-        """
-        Mount volume on authenticated client
-
-        Args:
-            mount_obj(obj): Object of GlusterMount class
-        """
-        # Mount volume
-        ret = mount_obj.mount()
-        self.assertTrue(ret, ("Failed to mount %s on client %s" %
-                              (mount_obj.volname,
-                               mount_obj.client_system)))
-        g.log.info("Successfully mounted %s on client %s", mount_obj.volname,
-                   mount_obj.client_system)
-
-        # Verify mount
-        ret = mount_obj.is_mounted()
-        self.assertTrue(ret, ("%s is not mounted on client %s"
-                              % (mount_obj.volname, mount_obj.client_system)))
-        g.log.info("Verified: %s is mounted on client %s",
-                   mount_obj.volname, mount_obj.client_system)
-
-    def unauthenticated_mount(self, mount_obj):
-        """
-        Try to mount volume on unauthenticated client
-        Args:
-            mount_obj(obj): Object of GlusterMount class
-        """
-        # Try to mount volume and verify
-        # Sometimes the mount command is returning exit code as 0 in case of
-        # mount failures as well.
-        # Hence not asserting while running mount command in test case.
-        # Instead asserting only if it is actually mounted.
-        # BZ 1590711
-        mount_obj.mount()
-
-        # Verify mount
-        ret = mount_obj.is_mounted()
-        if ret:
-            # Mount operation did not fail as expected. Cleanup the mount.
-            if not mount_obj.unmount():
-                g.log.error("Failed to unmount %s from client %s",
-                            mount_obj.volname, mount_obj.client_system)
-        self.assertFalse(ret, ("Mount operation did not fail as "
-                               "expected. Mount operation of "
-                               "%s on client %s passed. "
-                               "Mount point: %s"
-                               % (mount_obj.volname,
-                                  mount_obj.client_system,
-                                  mount_obj.mountpoint)))
-        g.log.info("Mount operation of %s on client %s failed as "
-                   "expected", mount_obj.volname, mount_obj.client_system)
-
-    def is_auth_failure(self, client_ip, previous_log_statement=''):
-        """
-        Check if the mount failure is due to authentication error
-        Args:
-            client_ip(str): IP of client in which mount failure has to be
-                verified.
-            previous_log_statement(str): AUTH_FAILED message of previous mount
-                failure due to auth error(if any). This is used to distinguish
-                between the current and previous message.
-        Return(str):
-            Latest AUTH_FAILED event log message.
-        """
-        # Command to find the log file
-        cmd = "ls /var/log/glusterfs/ -1t | head -1"
-        ret, out, _ = g.run(client_ip, cmd)
-        self.assertEqual(ret, 0, "Failed to find the log file.")
-
-        # Command to fetch latest AUTH_FAILED event log message.
-        cmd = "grep AUTH_FAILED /var/log/glusterfs/%s | tail -1" % out.strip()
-        ret, current_log_statement, _ = g.run(client_ip, cmd)
-        self.assertEqual(ret, 0, "Mount failure is not due to auth error")
-
-        # Check whether the AUTH_FAILED log is of the latest mount failure
-        self.assertNotEqual(current_log_statement.strip(),
-                            previous_log_statement,
-                            "Mount failure is not due to authentication "
-                            "error")
-        g.log.info("Mount operation has failed due to authentication error")
-        return current_log_statement.strip()
-
-    def test_auth_allow(self):
+    def run_test(self, redant):
         """
         Verify auth.allow feature using client ip and hostname.
         Steps:
@@ -140,67 +51,47 @@ class FuseAuthAllow(GlusterBaseClass):
         9. Unmount the volume from client1.
         """
         # Setting authentication on volume for client1 using ip
-        auth_dict = {'all': [self.mounts[0].client_system]}
-        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set authentication")
+        auth_dict = {'all': [self.client_list[0]]}
+        if not redant.set_auth_allow(self.vol_name, self.server_list[0],
+                                     auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Mounting volume on client1
-        self.authenticated_mount(self.mounts[0])
+        redant.authenticated_mount(self.vol_name, self.server_list[0],
+                                   self.mountpoint, self.client_list[0])
 
         # Trying to mount volume on client2
-        self.unauthenticated_mount(self.mounts[1])
+        redant.unauthenticated_mount(self.vol_name, self.server_list[0],
+                                     self.mountpoint, self.client_list[1])
 
         # Verify whether mount failure on client2 is due to auth error
-        log_msg = self.is_auth_failure(self.mounts[1].client_system)
-        prev_log_statement = log_msg
-
-        g.log.info("Verification of auth.allow on volume using client IP is "
-                   "successful")
+        prev_log_statement = redant.is_auth_failure(self.client_list[1])
 
         # Unmount volume from client1
-        ret = self.mounts[0].unmount()
-        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
-                              % (self.volname, self.mounts[0].client_system)))
+        redant.volume_unmount(self.vol_name, self.mountpoint,
+                              self.client_list[0])
 
         # Obtain hostname of client1
-        ret, hostname_client1, _ = g.run(self.mounts[0].client_system,
-                                         "hostname")
-        self.assertEqual(ret, 0, ("Failed to obtain hostname of client %s"
-                                  % self.mounts[0].client_system))
-        g.log.info("Obtained hostname of client. IP- %s, hostname- %s",
-                   self.mounts[0].client_system, hostname_client1.strip())
+        ret = redant.execute_abstract_op_node("hostname", self.client_list[0])
+        hostname_client1 = ret['msg'].rstrip('\n')
 
         # Setting authentication on volume for client1 using hostname
-        auth_dict = {'all': [hostname_client1.strip()]}
-        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set authentication")
+        auth_dict = {'all': [hostname_client1]}
+        if not redant.set_auth_allow(self.vol_name, self.server_list[0],
+                                     auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Mounting volume on client1
-        self.authenticated_mount(self.mounts[0])
+        redant.authenticated_mount(self.vol_name, self.server_list[0],
+                                   self.mountpoint, self.client_list[0])
 
         # Trying to mount volume on client2
-        self.unauthenticated_mount(self.mounts[1])
+        redant.unauthenticated_mount(self.vol_name, self.server_list[0],
+                                     self.mountpoint, self.client_list[1])
 
         # Verify whether mount failure on client2 is due to auth error
-        log_msg = self.is_auth_failure(self.mounts[1].client_system,
-                                       prev_log_statement)
-        prev_log_statement = log_msg
-
-        g.log.info("Verification of auth.allow on volume using client "
-                   "hostname is successful")
+        redant.is_auth_failure(self.client_list[1], prev_log_statement)
 
         # Unmount volume from client1
-        ret = self.mounts[0].unmount()
-        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
-                              % (self.volname, self.mounts[0].client_system)))
-
-    def tearDown(self):
-        """
-        Cleanup volume
-        """
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to cleanup volume.")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        redant.volume_unmount(self.vol_name, self.mountpoint,
+                              self.client_list[0])

--- a/tests/functional/authentication/test_auth_allow.py
+++ b/tests/functional/authentication/test_auth_allow.py
@@ -1,0 +1,211 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+        Test cases in this module tests the authentication allow feature
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
+                                                   runs_on)
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.auth_ops import set_auth_allow
+
+
+@runs_on([['replicated', 'distributed', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'],
+          ['glusterfs']])
+class FuseAuthAllow(GlusterBaseClass):
+    """
+    Tests to verify auth.allow feature on fuse mount.
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create and start volume
+        """
+        GlusterBaseClass.setUpClass.im_func(cls)
+        # Create and start volume
+        g.log.info("Starting volume setup process %s", cls.volname)
+        ret = cls.setup_volume()
+        if not ret:
+            raise ExecutionError("Failed to setup "
+                                 "and start volume %s" % cls.volname)
+        g.log.info("Successfully created and started the volume: %s",
+                   cls.volname)
+
+    def authenticated_mount(self, mount_obj):
+        """
+        Mount volume on authenticated client
+
+        Args:
+            mount_obj(obj): Object of GlusterMount class
+        """
+        # Mount volume
+        ret = mount_obj.mount()
+        self.assertTrue(ret, ("Failed to mount %s on client %s" %
+                              (mount_obj.volname,
+                               mount_obj.client_system)))
+        g.log.info("Successfully mounted %s on client %s", mount_obj.volname,
+                   mount_obj.client_system)
+
+        # Verify mount
+        ret = mount_obj.is_mounted()
+        self.assertTrue(ret, ("%s is not mounted on client %s"
+                              % (mount_obj.volname, mount_obj.client_system)))
+        g.log.info("Verified: %s is mounted on client %s",
+                   mount_obj.volname, mount_obj.client_system)
+
+    def unauthenticated_mount(self, mount_obj):
+        """
+        Try to mount volume on unauthenticated client
+        Args:
+            mount_obj(obj): Object of GlusterMount class
+        """
+        # Try to mount volume and verify
+        # Sometimes the mount command is returning exit code as 0 in case of
+        # mount failures as well.
+        # Hence not asserting while running mount command in test case.
+        # Instead asserting only if it is actually mounted.
+        # BZ 1590711
+        mount_obj.mount()
+
+        # Verify mount
+        ret = mount_obj.is_mounted()
+        if ret:
+            # Mount operation did not fail as expected. Cleanup the mount.
+            if not mount_obj.unmount():
+                g.log.error("Failed to unmount %s from client %s",
+                            mount_obj.volname, mount_obj.client_system)
+        self.assertFalse(ret, ("Mount operation did not fail as "
+                               "expected. Mount operation of "
+                               "%s on client %s passed. "
+                               "Mount point: %s"
+                               % (mount_obj.volname,
+                                  mount_obj.client_system,
+                                  mount_obj.mountpoint)))
+        g.log.info("Mount operation of %s on client %s failed as "
+                   "expected", mount_obj.volname, mount_obj.client_system)
+
+    def is_auth_failure(self, client_ip, previous_log_statement=''):
+        """
+        Check if the mount failure is due to authentication error
+        Args:
+            client_ip(str): IP of client in which mount failure has to be
+                verified.
+            previous_log_statement(str): AUTH_FAILED message of previous mount
+                failure due to auth error(if any). This is used to distinguish
+                between the current and previous message.
+        Return(str):
+            Latest AUTH_FAILED event log message.
+        """
+        # Command to find the log file
+        cmd = "ls /var/log/glusterfs/ -1t | head -1"
+        ret, out, _ = g.run(client_ip, cmd)
+        self.assertEqual(ret, 0, "Failed to find the log file.")
+
+        # Command to fetch latest AUTH_FAILED event log message.
+        cmd = "grep AUTH_FAILED /var/log/glusterfs/%s | tail -1" % out.strip()
+        ret, current_log_statement, _ = g.run(client_ip, cmd)
+        self.assertEqual(ret, 0, "Mount failure is not due to auth error")
+
+        # Check whether the AUTH_FAILED log is of the latest mount failure
+        self.assertNotEqual(current_log_statement.strip(),
+                            previous_log_statement,
+                            "Mount failure is not due to authentication "
+                            "error")
+        g.log.info("Mount operation has failed due to authentication error")
+        return current_log_statement.strip()
+
+    def test_auth_allow(self):
+        """
+        Verify auth.allow feature using client ip and hostname.
+        Steps:
+        1. Setup and start volume
+        2. Set auth.allow on volume for client1 using ip of client1
+        3. Mount volume on client1.
+        4. Try to mount volume on client2. This should fail.
+        5. Check the client2 logs for AUTH_FAILED event.
+        6. Unmount the volume from client1.
+        7. Set auth.allow on volume for client1 using hostname of client1.
+        8. Repeat steps 3 to 5.
+        9. Unmount the volume from client1.
+        """
+        # Setting authentication on volume for client1 using ip
+        auth_dict = {'all': [self.mounts[0].client_system]}
+        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set authentication")
+        g.log.info("Successfully set authentication on volume")
+
+        # Mounting volume on client1
+        self.authenticated_mount(self.mounts[0])
+
+        # Trying to mount volume on client2
+        self.unauthenticated_mount(self.mounts[1])
+
+        # Verify whether mount failure on client2 is due to auth error
+        log_msg = self.is_auth_failure(self.mounts[1].client_system)
+        prev_log_statement = log_msg
+
+        g.log.info("Verification of auth.allow on volume using client IP is "
+                   "successful")
+
+        # Unmount volume from client1
+        ret = self.mounts[0].unmount()
+        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
+                              % (self.volname, self.mounts[0].client_system)))
+
+        # Obtain hostname of client1
+        ret, hostname_client1, _ = g.run(self.mounts[0].client_system,
+                                         "hostname")
+        self.assertEqual(ret, 0, ("Failed to obtain hostname of client %s"
+                                  % self.mounts[0].client_system))
+        g.log.info("Obtained hostname of client. IP- %s, hostname- %s",
+                   self.mounts[0].client_system, hostname_client1.strip())
+
+        # Setting authentication on volume for client1 using hostname
+        auth_dict = {'all': [hostname_client1.strip()]}
+        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set authentication")
+        g.log.info("Successfully set authentication on volume")
+
+        # Mounting volume on client1
+        self.authenticated_mount(self.mounts[0])
+
+        # Trying to mount volume on client2
+        self.unauthenticated_mount(self.mounts[1])
+
+        # Verify whether mount failure on client2 is due to auth error
+        log_msg = self.is_auth_failure(self.mounts[1].client_system,
+                                       prev_log_statement)
+        prev_log_statement = log_msg
+
+        g.log.info("Verification of auth.allow on volume using client "
+                   "hostname is successful")
+
+        # Unmount volume from client1
+        ret = self.mounts[0].unmount()
+        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
+                              % (self.volname, self.mounts[0].client_system)))
+
+    def tearDown(self):
+        """
+        Cleanup volume
+        """
+        g.log.info("Cleaning up volume")
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to cleanup volume.")
+        g.log.info("Volume cleanup was successful.")

--- a/tests/vol_create_test.py
+++ b/tests/vol_create_test.py
@@ -30,9 +30,8 @@ class VolCreate(LazyParentTest):
         of said type so that tests can use it.
         """
         vol_param = self.vol_type_inf[self.volume_type]
-        redant.volume_create(self.vol_name, self.server_list[0], vol_param,
-                             self.server_list, self.brick_roots, True)
-        redant.volume_start(self.vol_name, self.server_list[0])
+        redant.setup_volume(self.vol_name, self.server_list[0], vol_param,
+                            self.server_list, self.brick_roots, force=True)
         redant.execute_abstract_op_node(f"mkdir -p {self.mountpoint}",
                                         self.client_list[0])
         redant.volume_mount(self.server_list[0], self.vol_name,


### PR DESCRIPTION
Migrated TC [test_auth_allow](https://github.com/gluster/glusto-tests/blob/master/tests/functional/authentication/test_auth_allow.py)
Added few functions in auth_ops file, as they are resued in multiple auth TCs

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>