### PR TITLE
Migrated TC test_authentication_allow_blank

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -1261,6 +1261,9 @@ class VolumeOps(AbstractOps):
                        f"{volume_options[option]} --mode=script --xml")
 
                 ret = self.execute_abstract_op_node(cmd, node, excep)
+                if not excep and ret['error_code'] != 0:
+                    return ret
+
                 if ret['msg']['opRet'] == '0':
                     if volname != 'all':
                         self.es.set_vol_option(

--- a/tests/functional/authentication/test_authentication_allow_blank.py
+++ b/tests/functional/authentication/test_authentication_allow_blank.py
@@ -28,8 +28,7 @@ from glustolibs.gluster.volume_libs import cleanup_volume
 
 
 @runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed-dispersed'],
-          ['glusterfs']])
+           'distributed-dispersed'], ['glusterfs']])
 class AuthAllowEmptyString(GlusterBaseClass):
     """
     Tests to verify auth.allow functionality on Volume and Fuse subdir
@@ -38,13 +37,12 @@ class AuthAllowEmptyString(GlusterBaseClass):
         """
         Setup Volume
         """
+        # Calling GlusterBaseClass Setup
+        self.get_super_method(self, 'setUp')()
+
         ret = self.setup_volume()
         if not ret:
             raise ExecutionError("Failed to setup volume")
-        g.log.info("Volume %s has been setup successfully", self.volname)
-
-        # Calling GlusterBaseClass Setup
-        self.get_super_method(self, 'setUp')()
 
     def test_validate_authallow(self):
         """
@@ -76,5 +74,6 @@ class AuthAllowEmptyString(GlusterBaseClass):
         if not ret:
             raise ExecutionError("Failed to Cleanup the "
                                  "Volume %s" % self.volname)
-        g.log.info("Volume deleted successfully "
-                   ": %s", self.volname)
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/authentication/test_authentication_allow_blank.py
+++ b/tests/functional/authentication/test_authentication_allow_blank.py
@@ -34,7 +34,7 @@ class TestAuthAllowEmptyString(NdParentTest):
         option = {"auth.allow": " "}
         ret = redant.set_volume_options(self.vol_name, option,
                                         self.server_list[0], excep=False)
-        if ret['msg']['opRet'] == '0':
+        if ret['error_code'] == 0:
             raise Exception("Unexpected: Authentication set successfully "
                             f"for Volume with option: {option}")
 

--- a/tests/functional/authentication/test_authentication_allow_blank.py
+++ b/tests/functional/authentication/test_authentication_allow_blank.py
@@ -1,79 +1,44 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-""" Description
-Test Case in this module is to set value of auth.allow to empty string
-and check if it throws an error
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
-                                                   runs_on)
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_init import is_glusterd_running
-from glustolibs.gluster.volume_ops import set_volume_options
-from glustolibs.gluster.volume_libs import cleanup_volume
+ Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to check if setting empty value in auth.allow throws an error
+"""
+
+# nonDisruptive;rep,dist-rep,disp,dist-disp
+from tests.nd_parent_test import NdParentTest
 
 
-@runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed-dispersed'], ['glusterfs']])
-class AuthAllowEmptyString(GlusterBaseClass):
-    """
-    Tests to verify auth.allow functionality on Volume and Fuse subdir
-    """
-    def setUp(self):
-        """
-        Setup Volume
-        """
-        # Calling GlusterBaseClass Setup
-        self.get_super_method(self, 'setUp')()
+class TestAuthAllowEmptyString(NdParentTest):
 
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup volume")
-
-    def test_validate_authallow(self):
+    def run_test(self, redant):
         """
         -Set Authentication allow as empty string for volume
         -Check if glusterd is running
         """
-        # pylint: disable=too-many-statements
-
         # Set Authentication to blank string for volume
         option = {"auth.allow": " "}
-        ret = set_volume_options(self.mnode, self.volname,
-                                 option)
-        self.assertFalse(ret, ("Unexpected: Authentication set successfully "
-                               "for Volume with option: %s" % option))
-        g.log.info("Expected: Failed to set authentication for Volume with "
-                   "option: %s", option)
+        ret = redant.set_volume_options(self.vol_name, option,
+                                        self.server_list[0], excep=False)
+        if ret['msg']['opRet'] == '0':
+            raise Exception("Unexpected: Authentication set successfully "
+                            f"for Volume with option: {option}")
 
         # Check if glusterd is running
-        ret = is_glusterd_running(self.servers)
-        self.assertEqual(ret, 0, "Glusterd service not running")
-        g.log.info("Expected : Glusterd service running")
-
-    def tearDown(self):
-        """
-        TearDown for Volume
-        Volume Cleanup
-        """
-        ret = cleanup_volume(self.mnode, self.volname)
-        if not ret:
-            raise ExecutionError("Failed to Cleanup the "
-                                 "Volume %s" % self.volname)
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        ret = redant.is_glusterd_running(self.server_list)
+        if ret != 1:
+            raise Exception("Glusterd service is not running")

--- a/tests/functional/authentication/test_authentication_allow_blank.py
+++ b/tests/functional/authentication/test_authentication_allow_blank.py
@@ -44,7 +44,7 @@ class AuthAllowEmptyString(GlusterBaseClass):
         g.log.info("Volume %s has been setup successfully", self.volname)
 
         # Calling GlusterBaseClass Setup
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
     def test_validate_authallow(self):
         """

--- a/tests/functional/authentication/test_authentication_allow_blank.py
+++ b/tests/functional/authentication/test_authentication_allow_blank.py
@@ -1,0 +1,80 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description
+Test Case in this module is to set value of auth.allow to empty string
+and check if it throws an error
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
+                                                   runs_on)
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_init import is_glusterd_running
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.gluster.volume_libs import cleanup_volume
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed-dispersed'],
+          ['glusterfs']])
+class AuthAllowEmptyString(GlusterBaseClass):
+    """
+    Tests to verify auth.allow functionality on Volume and Fuse subdir
+    """
+    def setUp(self):
+        """
+        Setup Volume
+        """
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Failed to setup volume")
+        g.log.info("Volume %s has been setup successfully", self.volname)
+
+        # Calling GlusterBaseClass Setup
+        GlusterBaseClass.setUp.im_func(self)
+
+    def test_validate_authallow(self):
+        """
+        -Set Authentication allow as empty string for volume
+        -Check if glusterd is running
+        """
+        # pylint: disable=too-many-statements
+
+        # Set Authentication to blank string for volume
+        option = {"auth.allow": " "}
+        ret = set_volume_options(self.mnode, self.volname,
+                                 option)
+        self.assertFalse(ret, ("Unexpected: Authentication set successfully "
+                               "for Volume with option: %s" % option))
+        g.log.info("Expected: Failed to set authentication for Volume with "
+                   "option: %s", option)
+
+        # Check if glusterd is running
+        ret = is_glusterd_running(self.servers)
+        self.assertEqual(ret, 0, "Glusterd service not running")
+        g.log.info("Expected : Glusterd service running")
+
+    def tearDown(self):
+        """
+        TearDown for Volume
+        Volume Cleanup
+        """
+        ret = cleanup_volume(self.mnode, self.volname)
+        if not ret:
+            raise ExecutionError("Failed to Cleanup the "
+                                 "Volume %s" % self.volname)
+        g.log.info("Volume deleted successfully "
+                   ": %s", self.volname)


### PR DESCRIPTION
Migrated TC [test_authentication_allow_blank](https://github.com/gluster/glusto-tests/blob/master/tests/functional/authentication/test_authentication_allow_blank.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>