### PR TITLE
Migrated TC test_auth_invalid_value

### DIFF
--- a/tests/functional/authentication/test_auth_invalid_values.py
+++ b/tests/functional/authentication/test_auth_invalid_values.py
@@ -1,0 +1,164 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+    Description:
+        Test cases in this module tests negative scenario of authentication
+        feature by giving invalid values.
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
+                                                   runs_on)
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.gluster.volume_libs import is_volume_exported
+
+
+@runs_on([['replicated', 'distributed', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'],
+          ['glusterfs', 'nfs']])
+class AuthInvalidValues(GlusterBaseClass):
+    """
+    Tests to verify negative scenario in authentication allow and reject
+    options by giving invalid values
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create and start volume
+        """
+        GlusterBaseClass.setUpClass.im_func(cls)
+        # Create and start volume
+        g.log.info("Starting volume setup process %s", cls.volname)
+        ret = cls.setup_volume()
+        if not ret:
+            raise ExecutionError("Failed to setup "
+                                 "and start volume %s" % cls.volname)
+        g.log.info("Successfully created and started the volume: %s",
+                   cls.volname)
+
+    def set_invalid_auth(self, auth_opt, values_list):
+        """
+        Try to set invalid values on authentication options.
+
+        Args:
+            auth_opt(str): Authentication option which has to be set.
+            values_list(list): List of invalid values.
+        Return(bool):
+            True if set command failed due to invalid value.
+            False if the failure is due to some other reason.
+        """
+        error_msg_fuse = "not a valid internet-address-list"
+        error_msg_nfs = "not a valid mount-auth-address"
+
+        # Try to set invalid values.
+        for value in values_list:
+            auth_cmd = ("gluster volume set %s %s \"%s\""
+                        % (self.volname, auth_opt, value))
+            ret, _, err = g.run(self.mnode, auth_cmd)
+            self.assertNotEqual(ret, 0, "Command to set %s value as %s didn't"
+                                        " fail as expected." % (auth_opt,
+                                                                value))
+
+            # Verify whether the failure is due to invalid value.
+            if self.mount_type == "nfs":
+                if error_msg_nfs not in err:
+                    g.log.error("Command to set %s value as %s has failed due"
+                                " to unknown reason.", auth_opt, value)
+                    return False
+
+            if self.mount_type == "glusterfs":
+                if error_msg_fuse not in err:
+                    g.log.error("Command to set %s value as %s has failed due"
+                                " to unknown reason.", auth_opt, value)
+                    return False
+
+            g.log.info("Expected: Command to set %s value as %s has"
+                       " failed due to invalid value.", auth_opt, value)
+        return True
+
+    def test_auth_invalid_values(self):
+        """
+        Verify negative scenario in authentication allow and reject options by
+        trying to set invalid values.
+        Steps:
+        1. Create and start volume.
+        2. Try to set the value "a/a", "192.{}.1.2", "/d1(a/a)",
+           "/d1(192.{}.1.2)" separately in auth.allow option.
+        3. Try to set the value "a/a", "192.{}.1.2", "/d1(a/a)",
+           "/d1(192.{}.1.2)" separately in auth.reject option.
+        4. Steps 2 and 3 should fail due to error "not a valid
+           internet-address-list"
+        5. Verify volume is exported as nfs.
+        6. Try to set the value "a/a", "192.{}.1.2", "/d1(a/a)",
+           "/d1(192.{}.1.2)" separately in nfs.rpc-auth-allow option.
+        7. Try to set the value "a/a", "192.{}.1.2", "/d1(a/a)",
+           "/d1(192.{}.1.2)" separately in nfs.rpc-auth-reject option.
+        8. Steps 6 and 7 should fail due to error "not a valid
+           mount-auth-address"
+        """
+        invalid_values = ["a/a", "192.{}.1.2", "/d1(a/a)", "/d1(192.{}.1.2)"]
+
+        if self.mount_type == "glusterfs":
+            # Try to set invalid values in auth.allow option.
+            ret = self.set_invalid_auth("auth.allow", invalid_values)
+            self.assertTrue(ret, "Failure of command to set auth.allow value "
+                                 "is not because of invalid values.")
+            g.log.info("Successfully verified auth.allow set command using"
+                       " invalid values. Command failed as expected.")
+
+            # Try to set invalid values in auth.reject option.
+            ret = self.set_invalid_auth("auth.reject", invalid_values)
+            self.assertTrue(ret, "Failure of command to set auth.reject value"
+                                 " is not because of invalid values.")
+            g.log.info("Successfully verified auth.reject set command using"
+                       " invalid values. Command failed as expected.")
+
+        if self.mount_type == "nfs":
+            # Check whether volume is exported as gnfs
+            ret = is_volume_exported(self.mnode, self.volname,
+                                     self.mount_type)
+            self.assertTrue(ret, "Volume is not exported as nfs")
+
+            # Enable nfs.addr-namelookup option.
+            ret = set_volume_options(self.mnode, self.volname,
+                                     {"nfs.addr-namelookup": "enable"})
+            self.assertTrue(ret, "Failed to enable nfs.addr-namelookup "
+                                 "option.")
+
+            # Try to set invalid values in nfs.rpc-auth-allow option.
+            ret = self.set_invalid_auth("nfs.rpc-auth-allow", invalid_values)
+            self.assertTrue(ret, "Command failure to set nfs.rpc-auth-allow"
+                                 " value is not because of invalid values.")
+            g.log.info("Successfully verified nfs.rpc-auth-allow set command"
+                       " using invalid values. Command failed as expected.")
+
+            # Try to set invalid values in nfs.rpc-auth-reject option.
+            self.set_invalid_auth("nfs.rpc-auth-reject", invalid_values)
+            self.assertTrue(ret, "Command failure to set nfs.rpc-auth-reject"
+                                 " value is not because of invalid values.")
+            g.log.info("Successfully verified nfs.rpc-auth-reject set command"
+                       " using invalid values. Command failed as expected.")
+
+    def tearDown(self):
+        """
+        Cleanup volume
+        """
+        g.log.info("Cleaning up volume")
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to cleanup volume.")
+        g.log.info("Volume cleanup was successful.")

--- a/tests/functional/authentication/test_auth_invalid_values.py
+++ b/tests/functional/authentication/test_auth_invalid_values.py
@@ -1,92 +1,73 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-    Description:
-        Test cases in this module tests negative scenario of authentication
-        feature by giving invalid values.
+ Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to tests negative scenario of authentication feature by giving
+    invalid values.
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
-                                                   runs_on)
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.volume_ops import set_volume_options
-from glustolibs.gluster.volume_libs import is_volume_exported
+
+# disruptive;dist,rep,dist-rep,disp,dist-disp
+# TODO: Add nfs
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed', 'distributed-replicated', 'dispersed',
-           'distributed-dispersed'], ['glusterfs', 'nfs']])
-class AuthInvalidValues(GlusterBaseClass):
-    """
-    Tests to verify negative scenario in authentication allow and reject
-    options by giving invalid values
-    """
-    @classmethod
-    def setUpClass(cls):
-        """
-        Create and start volume
-        """
-        cls.get_super_method(cls, 'setUpClass')()
-        # Create and start volume
-        ret = cls.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup "
-                                 "and start volume %s" % cls.volname)
+class TestAuthInvalidValues(DParentTest):
 
-    def set_invalid_auth(self, auth_opt, values_list):
+    def _set_invalid_auth(self, auth_opt, values_list):
         """
         Try to set invalid values on authentication options.
-
-        Args:
-            auth_opt(str): Authentication option which has to be set.
-            values_list(list): List of invalid values.
-        Return(bool):
-            True if set command failed due to invalid value.
-            False if the failure is due to some other reason.
         """
         error_msg_fuse = "not a valid internet-address-list"
-        error_msg_nfs = "not a valid mount-auth-address"
+        # NFS not supported, yet
+        # error_msg_nfs = "not a valid mount-auth-address"
 
         # Try to set invalid values.
         for value in values_list:
-            auth_cmd = ("gluster volume set %s %s \"%s\""
-                        % (self.volname, auth_opt, value))
-            ret, _, err = g.run(self.mnode, auth_cmd)
-            self.assertNotEqual(ret, 0, "Command to set %s value as %s didn't"
-                                        " fail as expected." % (auth_opt,
-                                                                value))
+            auth_cmd = (f"gluster volume set {self.vol_name} {auth_opt} "
+                        f"\"{value}\"")
+            ret = self.redant.execute_abstract_op_node(auth_cmd,
+                                                       self.server_list[0],
+                                                       False)
+            if ret['error_code'] == 0:
+                raise Exception(f"Command to set {auth_opt} value as {value}"
+                                " didn't fail as expected.")
 
+            # NFS not yet supported
             # Verify whether the failure is due to invalid value.
-            if self.mount_type == "nfs":
-                if error_msg_nfs not in err:
-                    g.log.error("Command to set %s value as %s has failed due"
-                                " to unknown reason.", auth_opt, value)
-                    return False
+            # if self.mount_type == "nfs":
+            #     if error_msg_nfs not in err:
+            #         g.log.error("Command to set %s value as %s has failed"
+            #                     " due to unknown reason.", auth_opt, value)
+            #         return False
 
-            if self.mount_type == "glusterfs":
-                if error_msg_fuse not in err:
-                    g.log.error("Command to set %s value as %s has failed due"
-                                " to unknown reason.", auth_opt, value)
-                    return False
+            # Uncomment below check after NFS is supported
+            # if self.mount_type == "glusterfs":
+            if error_msg_fuse not in ret['error_msg']:
+                self.redant.logger.error(f"Command to set {auth_opt} value"
+                                         f" as {value} has failed due to "
+                                         "unknown reason.")
+                return False
 
-            g.log.info("Expected: Command to set %s value as %s has"
-                       " failed due to invalid value.", auth_opt, value)
+            self.redant.logger.info(f"Expected: Command to set {auth_opt} "
+                                    f"value as {value} has failed due to "
+                                    "invalid value.")
         return True
 
-    def test_auth_invalid_values(self):
+    def run_test(self, redant):
         """
         Verify negative scenario in authentication allow and reject options by
         trying to set invalid values.
@@ -98,6 +79,9 @@ class AuthInvalidValues(GlusterBaseClass):
            "/d1(192.{}.1.2)" separately in auth.reject option.
         4. Steps 2 and 3 should fail due to error "not a valid
            internet-address-list"
+        -------------------------
+        Not yet implemented
+        -------------------------
         5. Verify volume is exported as nfs.
         6. Try to set the value "a/a", "192.{}.1.2", "/d1(a/a)",
            "/d1(192.{}.1.2)" separately in nfs.rpc-auth-allow option.
@@ -106,56 +90,45 @@ class AuthInvalidValues(GlusterBaseClass):
         8. Steps 6 and 7 should fail due to error "not a valid
            mount-auth-address"
         """
+        # pylint: disable = unused-argument
         invalid_values = ["a/a", "192.{}.1.2", "/d1(a/a)", "/d1(192.{}.1.2)"]
 
-        if self.mount_type == "glusterfs":
-            # Try to set invalid values in auth.allow option.
-            ret = self.set_invalid_auth("auth.allow", invalid_values)
-            self.assertTrue(ret, "Failure of command to set auth.allow value "
-                                 "is not because of invalid values.")
-            g.log.info("Successfully verified auth.allow set command using"
-                       " invalid values. Command failed as expected.")
-
-            # Try to set invalid values in auth.reject option.
-            ret = self.set_invalid_auth("auth.reject", invalid_values)
-            self.assertTrue(ret, "Failure of command to set auth.reject value"
-                                 " is not because of invalid values.")
-            g.log.info("Successfully verified auth.reject set command using"
-                       " invalid values. Command failed as expected.")
-
-        if self.mount_type == "nfs":
-            # Check whether volume is exported as gnfs
-            ret = is_volume_exported(self.mnode, self.volname,
-                                     self.mount_type)
-            self.assertTrue(ret, "Volume is not exported as nfs")
-
-            # Enable nfs.addr-namelookup option.
-            ret = set_volume_options(self.mnode, self.volname,
-                                     {"nfs.addr-namelookup": "enable"})
-            self.assertTrue(ret, "Failed to enable nfs.addr-namelookup "
-                                 "option.")
-
-            # Try to set invalid values in nfs.rpc-auth-allow option.
-            ret = self.set_invalid_auth("nfs.rpc-auth-allow", invalid_values)
-            self.assertTrue(ret, "Command failure to set nfs.rpc-auth-allow"
-                                 " value is not because of invalid values.")
-            g.log.info("Successfully verified nfs.rpc-auth-allow set command"
-                       " using invalid values. Command failed as expected.")
-
-            # Try to set invalid values in nfs.rpc-auth-reject option.
-            self.set_invalid_auth("nfs.rpc-auth-reject", invalid_values)
-            self.assertTrue(ret, "Command failure to set nfs.rpc-auth-reject"
-                                 " value is not because of invalid values.")
-            g.log.info("Successfully verified nfs.rpc-auth-reject set command"
-                       " using invalid values. Command failed as expected.")
-
-    def tearDown(self):
-        """
-        Cleanup volume
-        """
-        ret = self.cleanup_volume()
+        # Try to set invalid values in auth.allow option.
+        ret = self._set_invalid_auth("auth.allow", invalid_values)
         if not ret:
-            raise ExecutionError("Failed to cleanup volume.")
+            raise Exception("Failure of command to set auth.allow value "
+                            "is not because of invalid values.")
 
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        # Try to set invalid values in auth.reject option.
+        ret = self._set_invalid_auth("auth.reject", invalid_values)
+        if not ret:
+            raise Exception("Failure of command to set auth.reject value"
+                            " is not because of invalid values.")
+
+        # Uncomment and update the TC after NFS is supported in Redant
+        # if self.mount_type == "nfs":
+        #     # Check whether volume is exported as gnfs
+        #     ret = is_volume_exported(self.mnode, self.volname,
+        #                              self.mount_type)
+        #     self.assertTrue(ret, "Volume is not exported as nfs")
+
+        #     # Enable nfs.addr-namelookup option.
+        #     ret = set_volume_options(self.mnode, self.volname,
+        #                              {"nfs.addr-namelookup": "enable"})
+        #     self.assertTrue(ret, "Failed to enable nfs.addr-namelookup "
+        #                          "option.")
+
+        #     # Try to set invalid values in nfs.rpc-auth-allow option.
+        #     ret = self.set_invalid_auth("nfs.rpc-auth-allow", invalid_values)
+        #     self.assertTrue(ret, "Command failure to set nfs.rpc-auth-allow"
+        #                          " value is not because of invalid values.")
+        #     g.log.info("Successfully verified nfs.rpc-auth-allow set command"
+        #                " using invalid values. Command failed as expected.")
+
+        #     # Try to set invalid values in nfs.rpc-auth-reject option.
+        #     self.set_invalid_auth("nfs.rpc-auth-reject", invalid_values)
+        #     self.assertTrue(ret, "Command failure to set nfs.rpc-auth-reject"
+        #                          " value is not because of invalid values.")
+        #     g.log.info("Successfully verified nfs.rpc-auth-reject set "
+        #                "command using invalid values. Command failed "
+        #                "as expected.")

--- a/tests/functional/authentication/test_auth_invalid_values.py
+++ b/tests/functional/authentication/test_auth_invalid_values.py
@@ -27,9 +27,8 @@ from glustolibs.gluster.volume_ops import set_volume_options
 from glustolibs.gluster.volume_libs import is_volume_exported
 
 
-@runs_on([['replicated', 'distributed', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'],
-          ['glusterfs', 'nfs']])
+@runs_on([['replicated', 'distributed', 'distributed-replicated', 'dispersed',
+           'distributed-dispersed'], ['glusterfs', 'nfs']])
 class AuthInvalidValues(GlusterBaseClass):
     """
     Tests to verify negative scenario in authentication allow and reject
@@ -42,13 +41,10 @@ class AuthInvalidValues(GlusterBaseClass):
         """
         cls.get_super_method(cls, 'setUpClass')()
         # Create and start volume
-        g.log.info("Starting volume setup process %s", cls.volname)
         ret = cls.setup_volume()
         if not ret:
             raise ExecutionError("Failed to setup "
                                  "and start volume %s" % cls.volname)
-        g.log.info("Successfully created and started the volume: %s",
-                   cls.volname)
 
     def set_invalid_auth(self, auth_opt, values_list):
         """
@@ -157,8 +153,9 @@ class AuthInvalidValues(GlusterBaseClass):
         """
         Cleanup volume
         """
-        g.log.info("Cleaning up volume")
         ret = self.cleanup_volume()
         if not ret:
             raise ExecutionError("Failed to cleanup volume.")
-        g.log.info("Volume cleanup was successful.")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/authentication/test_auth_invalid_values.py
+++ b/tests/functional/authentication/test_auth_invalid_values.py
@@ -40,7 +40,7 @@ class AuthInvalidValues(GlusterBaseClass):
         """
         Create and start volume
         """
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         # Create and start volume
         g.log.info("Starting volume setup process %s", cls.volname)
         ret = cls.setup_volume()


### PR DESCRIPTION
Migrated TC [test_auth_invalid_value](https://github.com/gluster/glusto-tests/blob/master/tests/functional/authentication/test_auth_invalid_values.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>