### PR TITLE
[Common] Glusterd ungraceful kill added.

### DIFF
--- a/common/ops/gluster_ops/glusterd_ops.py
+++ b/common/ops/gluster_ops/glusterd_ops.py
@@ -233,7 +233,7 @@ class GlusterdOps(AbstractOps):
 
     def kill_glusterd_ungraceful(self, node: str):
         """
-        Method to kill glusterd, given its pid.
+        Method to kill glusterd, given its pid is active.
 
         Args:
             node (str|list): Node(s) on which this is to be executed.

--- a/common/ops/gluster_ops/glusterd_ops.py
+++ b/common/ops/gluster_ops/glusterd_ops.py
@@ -244,9 +244,7 @@ class GlusterdOps(AbstractOps):
 
         for nd in node:
             ret = self.execute_abstract_op_node(cmd1, nd, False)
-            if ret['error_code'] == 1:
-                continue
-            elif ret['error_code'] == 0:
+            if ret['error_code'] == 0:
                 pid = ret['msg'][0].strip()
                 cmd2 = f"kill -9 {pid}"
                 self.execute_abstract_op_node(cmd2, nd)

--- a/common/ops/gluster_ops/glusterd_ops.py
+++ b/common/ops/gluster_ops/glusterd_ops.py
@@ -231,6 +231,26 @@ class GlusterdOps(AbstractOps):
             count += 1
         return False
 
+    def kill_glusterd_ungraceful(self, node: str):
+        """
+        Method to kill glusterd, given its pid.
+
+        Args:
+            node (str|list): Node(s) on which this is to be executed.
+        """
+        if not isinstance(node, list):
+            node = [node]
+        cmd1 = "pidof glusterd"
+
+        for nd in node:
+            ret = self.execute_abstract_op_node(cmd1, nd, False)
+            if ret['error_code'] == 1:
+                continue
+            elif ret['error_code'] == 0:
+                pid = ret['msg'][0].strip()
+                cmd2 = f"kill -9 {pid}"
+                self.execute_abstract_op_node(cmd2, nd)
+
     def wait_for_glusterd_to_stop(self, node: str, timeout: int = 80) -> bool:
         """
         Checks the glusterd has stopeed already or waits for
@@ -248,6 +268,8 @@ class GlusterdOps(AbstractOps):
             ret = self.is_glusterd_running(node)
             if ret == 0:
                 return True
+            elif ret == -1:
+                self.kill_glusterd_ungraceful(node)
             sleep(1)
             count += 1
         return False


### PR DESCRIPTION
Sometimes glusterd doesn't stop with systemctl
stop command, this causes the wait_till_glusterd_to_stop
to go on unable to do anything. Hence added an ungraceful
mechanism to handle this corner case in glusterd.

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
