### PR TITLE
Migrated TC test_auth_reject_allow

### DIFF
--- a/common/ops/gluster_ops/auth_ops.py
+++ b/common/ops/gluster_ops/auth_ops.py
@@ -260,7 +260,8 @@ class AuthOps(AbstractOps):
             client (str): Node on which mounting has to be done
         """
         # Mount volume
-        self.volume_mount(server, volname, mountpoint, client)
+        cmd = f"mount.glusterfs {server}/{volname} {mountpoint}"
+        self.execute_abstract_op_node(cmd, client)
 
         # Verify mount
         ret = self.is_mounted(volname, mountpoint, client, server)
@@ -281,7 +282,8 @@ class AuthOps(AbstractOps):
         # Sometimes mount returns error code as 0, even though the mount
         # failed, so not checking the return value from volume_mount().
         # Mount volume
-        self.volume_mount(server, volname, mountpoint, client, False)
+        cmd = f"mount.glusterfs {server}/{volname} {mountpoint}"
+        self.execute_abstract_op_node(cmd, client, False)
 
         # Verify mount
         ret = self.is_mounted(volname, mountpoint, client, server)

--- a/common/ops/gluster_ops/auth_ops.py
+++ b/common/ops/gluster_ops/auth_ops.py
@@ -260,7 +260,7 @@ class AuthOps(AbstractOps):
             client (str): Node on which mounting has to be done
         """
         # Mount volume
-        cmd = f"mount.glusterfs {server}/{volname} {mountpoint}"
+        cmd = f"mount.glusterfs {server}:/{volname} {mountpoint}"
         self.execute_abstract_op_node(cmd, client)
 
         # Verify mount
@@ -282,7 +282,7 @@ class AuthOps(AbstractOps):
         # Sometimes mount returns error code as 0, even though the mount
         # failed, so not checking the return value from volume_mount().
         # Mount volume
-        cmd = f"mount.glusterfs {server}/{volname} {mountpoint}"
+        cmd = f"mount.glusterfs {server}:/{volname} {mountpoint}"
         self.execute_abstract_op_node(cmd, client, False)
 
         # Verify mount

--- a/tests/functional/authentication/test_auth_reject_allow.py
+++ b/tests/functional/authentication/test_auth_reject_allow.py
@@ -1,0 +1,329 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+        Test cases in this module tests the authentication allow feature
+        using auth.allow and auth.reject volume options
+"""
+import copy
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
+                                                   runs_on)
+from glustolibs.gluster.glusterdir import mkdir
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.auth_ops import set_auth_allow, set_auth_reject
+
+
+@runs_on([['replicated', 'distributed', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'],
+          ['glusterfs']])
+class FuseAuthRejectAllow(GlusterBaseClass):
+    """
+    Tests to verify auth.reject and auth.allow volume options in volume and
+    sub-directory level on fuse mount.
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create and start volume
+        """
+        GlusterBaseClass.setUpClass.im_func(cls)
+        # Create and start volume
+        g.log.info("Starting volume setup process %s", cls.volname)
+        ret = cls.setup_volume()
+        if not ret:
+            raise ExecutionError("Failed to setup "
+                                 "and start volume %s" % cls.volname)
+        g.log.info("Successfully created and started the volume: %s",
+                   cls.volname)
+
+    def authenticated_mount(self, mount_obj):
+        """
+        Mount volume/sub-directory on authenticated client
+
+        Args:
+            mount_obj(obj): Object of GlusterMount class
+        """
+        # Mount volume
+        ret = mount_obj.mount()
+        self.assertTrue(ret, ("Failed to mount %s on client %s" %
+                              (mount_obj.volname,
+                               mount_obj.client_system)))
+        g.log.info("Successfully mounted %s on client %s", mount_obj.volname,
+                   mount_obj.client_system)
+
+        # Verify mount
+        ret = mount_obj.is_mounted()
+        self.assertTrue(ret, ("%s is not mounted on client %s"
+                              % (mount_obj.volname, mount_obj.client_system)))
+        g.log.info("Verified: %s is mounted on client %s",
+                   mount_obj.volname, mount_obj.client_system)
+
+    def unauthenticated_mount(self, mount_obj):
+        """
+        Try to mount volume/sub-directoty on unauthenticated client
+        Args:
+            mount_obj(obj): Object of GlusterMount class
+        """
+        # Try to mount volume/sub-directory and verify
+        # Sometimes the mount command is returning exit code as 0 in case of
+        # mount failures as well.
+        # Hence not asserting while running mount command in test case.
+        # Instead asserting only if it is actually mounted.
+        # BZ 1590711
+        mount_obj.mount()
+
+        # Verify mount
+        ret = mount_obj.is_mounted()
+        if ret:
+            # Mount operation did not fail as expected. Cleanup the mount.
+            if not mount_obj.unmount():
+                g.log.error("Failed to unmount %s from client %s",
+                            mount_obj.volname, mount_obj.client_system)
+        self.assertFalse(ret, ("Mount operation did not fail as "
+                               "expected. Mount operation of "
+                               "%s on client %s passed. "
+                               "Mount point: %s"
+                               % (mount_obj.volname,
+                                  mount_obj.client_system,
+                                  mount_obj.mountpoint)))
+        g.log.info("Mount operation of %s on client %s failed as "
+                   "expected", mount_obj.volname, mount_obj.client_system)
+
+    def is_auth_failure(self, client_ip, previous_log_statement=''):
+        """
+        Check if the mount failure is due to authentication error
+        Args:
+            client_ip(str): IP of client in which mount failure has to be
+                verified.
+            previous_log_statement(str): AUTH_FAILED message of previous mount
+                failure due to auth error(if any). This is used to distinguish
+                between the current and previous message.
+        Return(str):
+            Latest AUTH_FAILED event log message.
+        """
+        # Command to find the log file
+        cmd = "ls /var/log/glusterfs/ -1t | head -1"
+        ret, out, _ = g.run(client_ip, cmd)
+        self.assertEqual(ret, 0, "Failed to find the log file.")
+
+        # Command to fetch latest AUTH_FAILED event log message.
+        cmd = "grep AUTH_FAILED /var/log/glusterfs/%s | tail -1" % out.strip()
+        ret, current_log_statement, _ = g.run(client_ip, cmd)
+        self.assertEqual(ret, 0, "Mount failure is not due to auth error")
+
+        # Check whether the AUTH_FAILED log is of the latest mount failure
+        self.assertNotEqual(current_log_statement.strip(),
+                            previous_log_statement,
+                            "Mount failure is not due to authentication "
+                            "error")
+        g.log.info("Mount operation has failed due to authentication error")
+        return current_log_statement.strip()
+
+    def test_auth_reject_allow(self):
+        """
+        Verify auth.reject and auth.allow volume options in volume level using
+        both client ip and hostname.
+        Verify auth.reject and auth.allow volume options in sub-directory
+        level using both client ip and hostname.
+        Steps:
+        1. Create and start volume.
+        2. Set auth.reject on volume for client1 using ip of client1.
+        3. Set auth.allow on volume for client2 using ip of client2.
+        4. Try to mount volume on client1. This should fail.
+        5. Check the client1 log for AUTH_FAILED event.
+        6. Mount volume on client2.
+        7. Unmount the volume from client2.
+        8. Set auth.reject on volume for client1 using hostname of client1.
+        9. Set auth.allow on volume for client2 using hostname of client2.
+        10. Repeat steps 4 to 6
+        11. Create directory d1 on client2 mountpoint.
+        12. Unmount the volume from client2.
+        13. Set auth.reject on d1 for client1 using ip of client1.
+        14. Set auth.allow on d1 for client2 using ip of client2.
+        15. Try to mount d1 on client1. This should fail.
+        16. Check the client1 log for AUTH_FAILED event.
+        17. Mount d1 on client2.
+        18. Unmount d1 from client2.
+        19. Set auth.reject on d1 for client1 using hostname of client1.
+        20. Set auth.allow on d1 for client2 using hostname of client2.
+        21. Repeat steps 15 to 18.
+        """
+        # pylint: disable = too-many-statements
+        # Setting auth.reject on volume for client1 using ip
+        auth_dict = {'all': [self.mounts[0].client_system]}
+        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        g.log.info("Successfully set auth.reject option on volume")
+
+        # Setting auth.allow on volume for client2 using ip
+        auth_dict = {'all': [self.mounts[1].client_system]}
+        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        g.log.info("Successfully set auth.allow option on volume")
+
+        # Trying to mount volume on client1
+        self.unauthenticated_mount(self.mounts[0])
+
+        # Verify whether mount failure on client1 is due to auth error
+        log_msg = self.is_auth_failure(self.mounts[0].client_system)
+        prev_log_statement = log_msg
+
+        # Mounting volume on client2
+        self.authenticated_mount(self.mounts[1])
+
+        g.log.info("Verification of auth.reject and auth.allow options on "
+                   "volume using client IP is successful")
+
+        # Unmount volume from client2
+        ret = self.mounts[1].unmount()
+        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
+                              % (self.volname, self.mounts[1].client_system)))
+
+        # Obtain hostname of client1
+        ret, hostname_client1, _ = g.run(self.mounts[0].client_system,
+                                         "hostname")
+        self.assertEqual(ret, 0, ("Failed to obtain hostname of client %s"
+                                  % self.mounts[0].client_system))
+        g.log.info("Obtained hostname of client. IP- %s, hostname- %s",
+                   self.mounts[0].client_system, hostname_client1.strip())
+
+        # Obtain hostname of client2
+        ret, hostname_client2, _ = g.run(self.mounts[1].client_system,
+                                         "hostname")
+        self.assertEqual(ret, 0, ("Failed to obtain hostname of client %s"
+                                  % self.mounts[1].client_system))
+        g.log.info("Obtained hostname of client. IP- %s, hostname- %s",
+                   self.mounts[1].client_system, hostname_client2.strip())
+
+        # Setting auth.reject on volume for client1 using hostname
+        auth_dict = {'all': [hostname_client1.strip()]}
+        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        g.log.info("Successfully set auth.reject option on volume")
+
+        # Setting auth.allow on volume for client2 using hostname
+        auth_dict = {'all': [hostname_client2.strip()]}
+        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        g.log.info("Successfully set auth.allow option on volume")
+
+        # Trying to mount volume on client1
+        self.unauthenticated_mount(self.mounts[0])
+
+        # Verify whether mount failure on client1 is due to auth error
+        log_msg = self.is_auth_failure(self.mounts[0].client_system,
+                                       prev_log_statement)
+        prev_log_statement = log_msg
+
+        # Mounting volume on client2
+        self.authenticated_mount(self.mounts[1])
+
+        g.log.info("Verification of auth.reject and auth.allow options on "
+                   "volume using client hostname is successful")
+
+        # Creating sub directory d1 on mounted volume
+        ret = mkdir(self.mounts[1].client_system, "%s/d1"
+                    % self.mounts[1].mountpoint)
+        self.assertTrue(ret, ("Failed to create directory 'd1' in volume %s "
+                              "from client %s"
+                              % (self.volname, self.mounts[1].client_system)))
+
+        # Unmount volume from client2
+        ret = self.mounts[1].unmount()
+        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
+                              % (self.volname, self.mounts[1].client_system)))
+
+        # Setting auth.reject on d1 for client1 using ip
+        auth_dict = {'/d1': [self.mounts[0].client_system]}
+        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        g.log.info("Successfully set auth.reject option.")
+
+        # Setting auth.allow on d1 for client2 using ip
+        auth_dict = {'/d1': [self.mounts[1].client_system]}
+        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        g.log.info("Successfully set auth.allow option.")
+
+        # Creating mount object for sub-directory mount on client1
+        mount_obj_client1 = copy.deepcopy(self.mounts[0])
+        mount_obj_client1.volname = "%s/d1" % self.volname
+
+        # Creating mount object for sub-directory mount on client2
+        mount_obj_client2 = copy.deepcopy(self.mounts[1])
+        mount_obj_client2.volname = "%s/d1" % self.volname
+
+        # Trying to mount d1 on client1
+        self.unauthenticated_mount(mount_obj_client1)
+
+        # Verify whether mount failure on client1 is due to auth error
+        log_msg = self.is_auth_failure(mount_obj_client1.client_system,
+                                       prev_log_statement)
+        prev_log_statement = log_msg
+
+        # Mounting d1 on client2
+        self.authenticated_mount(mount_obj_client2)
+
+        g.log.info("Verification of auth.reject and auth.allow options on "
+                   "sub-directory level using client IP is successful")
+
+        # Unmount d1 from client2
+        ret = mount_obj_client2.unmount()
+        self.assertTrue(ret, ("Failed to unmount %s from client %s"
+                              % (mount_obj_client2.volname,
+                                 mount_obj_client2.client_system)))
+
+        # Setting auth.reject on d1 for client1 using hostname
+        auth_dict = {'/d1': [hostname_client1.strip()]}
+        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        g.log.info("Successfully set auth.reject option.")
+
+        # Setting auth.allow on d1 for client2 using hostname
+        auth_dict = {'/d1': [hostname_client2.strip()]}
+        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
+        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        g.log.info("Successfully set auth.allow option.")
+
+        # Trying to mount d1 on client1
+        self.unauthenticated_mount(mount_obj_client1)
+
+        # Verify whether mount failure on client1 is due to auth error
+        self.is_auth_failure(mount_obj_client1.client_system,
+                             prev_log_statement)
+
+        # Mounting d1 on client2
+        self.authenticated_mount(mount_obj_client2)
+
+        g.log.info("Verification of auth.reject and auth.allow options on "
+                   "sub-directory level using client hostname is successful")
+
+        # Unmount d1 from client2
+        ret = mount_obj_client2.unmount()
+        self.assertTrue(ret, ("Failed to unmount %s from client %s"
+                              % (mount_obj_client2.volname,
+                                 mount_obj_client2.client_system)))
+
+    def tearDown(self):
+        """
+        Cleanup volume
+        """
+        g.log.info("Cleaning up volume")
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to cleanup volume.")
+        g.log.info("Volume cleanup was successful.")

--- a/tests/functional/authentication/test_auth_reject_allow.py
+++ b/tests/functional/authentication/test_auth_reject_allow.py
@@ -40,7 +40,7 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         """
         Create and start volume
         """
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         # Create and start volume
         g.log.info("Starting volume setup process %s", cls.volname)
         ret = cls.setup_volume()

--- a/tests/functional/authentication/test_auth_reject_allow.py
+++ b/tests/functional/authentication/test_auth_reject_allow.py
@@ -28,8 +28,7 @@ from glustolibs.gluster.auth_ops import set_auth_allow, set_auth_reject
 
 
 @runs_on([['replicated', 'distributed', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'],
-          ['glusterfs']])
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
 class FuseAuthRejectAllow(GlusterBaseClass):
     """
     Tests to verify auth.reject and auth.allow volume options in volume and
@@ -42,13 +41,10 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         """
         cls.get_super_method(cls, 'setUpClass')()
         # Create and start volume
-        g.log.info("Starting volume setup process %s", cls.volname)
         ret = cls.setup_volume()
         if not ret:
             raise ExecutionError("Failed to setup "
                                  "and start volume %s" % cls.volname)
-        g.log.info("Successfully created and started the volume: %s",
-                   cls.volname)
 
     def authenticated_mount(self, mount_obj):
         """
@@ -167,13 +163,11 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         auth_dict = {'all': [self.mounts[0].client_system]}
         ret = set_auth_reject(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.reject volume option.")
-        g.log.info("Successfully set auth.reject option on volume")
 
         # Setting auth.allow on volume for client2 using ip
         auth_dict = {'all': [self.mounts[1].client_system]}
         ret = set_auth_allow(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.allow volume option")
-        g.log.info("Successfully set auth.allow option on volume")
 
         # Trying to mount volume on client1
         self.unauthenticated_mount(self.mounts[0])
@@ -213,13 +207,11 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         auth_dict = {'all': [hostname_client1.strip()]}
         ret = set_auth_reject(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.reject volume option.")
-        g.log.info("Successfully set auth.reject option on volume")
 
         # Setting auth.allow on volume for client2 using hostname
         auth_dict = {'all': [hostname_client2.strip()]}
         ret = set_auth_allow(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.allow volume option")
-        g.log.info("Successfully set auth.allow option on volume")
 
         # Trying to mount volume on client1
         self.unauthenticated_mount(self.mounts[0])
@@ -251,13 +243,11 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         auth_dict = {'/d1': [self.mounts[0].client_system]}
         ret = set_auth_reject(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.reject volume option.")
-        g.log.info("Successfully set auth.reject option.")
 
         # Setting auth.allow on d1 for client2 using ip
         auth_dict = {'/d1': [self.mounts[1].client_system]}
         ret = set_auth_allow(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.allow volume option")
-        g.log.info("Successfully set auth.allow option.")
 
         # Creating mount object for sub-directory mount on client1
         mount_obj_client1 = copy.deepcopy(self.mounts[0])
@@ -291,13 +281,11 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         auth_dict = {'/d1': [hostname_client1.strip()]}
         ret = set_auth_reject(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.reject volume option.")
-        g.log.info("Successfully set auth.reject option.")
 
         # Setting auth.allow on d1 for client2 using hostname
         auth_dict = {'/d1': [hostname_client2.strip()]}
         ret = set_auth_allow(self.volname, self.mnode, auth_dict)
         self.assertTrue(ret, "Failed to set auth.allow volume option")
-        g.log.info("Successfully set auth.allow option.")
 
         # Trying to mount d1 on client1
         self.unauthenticated_mount(mount_obj_client1)
@@ -322,8 +310,9 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         """
         Cleanup volume
         """
-        g.log.info("Cleaning up volume")
         ret = self.cleanup_volume()
         if not ret:
             raise ExecutionError("Failed to cleanup volume.")
-        g.log.info("Volume cleanup was successful.")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/authentication/test_auth_reject_allow.py
+++ b/tests/functional/authentication/test_auth_reject_allow.py
@@ -33,11 +33,9 @@ class TestFuseAuthRejectAllow(DParentTest):
         """
         try:
             if self.is_vol_mounted:
-                cmd1 = f"umount {self.mountpoint}"
-                cmd2 = f"umount {self.subdir_vol}"
+                cmd = f"umount {self.mountpoint}"
                 for client in self.client_list:
-                    self.redant.execute_abstract_op_node(cmd1, client, False)
-                    self.redant.execute_abstract_op_node(cmd2, client, False)
+                    self.redant.execute_abstract_op_node(cmd, client, False)
 
         except Exception as error:
             tb = traceback.format_exc()
@@ -118,8 +116,8 @@ class TestFuseAuthRejectAllow(DParentTest):
         self.is_vol_mounted = True
 
         # Unmount volume from client2
-        redant.volume_unmount(self.vol_name, self.mountpoint,
-                              self.client_list[1])
+        cmd = f"umount {self.mountpoint}"
+        redant.execute_abstract_op_node(cmd, self.client_list[1])
         self.is_vol_mounted = False
 
         # Obtain hostname of client1
@@ -159,8 +157,8 @@ class TestFuseAuthRejectAllow(DParentTest):
         redant.create_dir(self.mountpoint, "d1", self.client_list[1])
 
         # Unmount volume from client2
-        redant.volume_unmount(self.vol_name, self.mountpoint,
-                              self.client_list[1])
+        cmd = f"umount {self.mountpoint}"
+        redant.execute_abstract_op_node(cmd, self.client_list[1])
         self.is_vol_mounted = False
 
         # Setting auth.reject on d1 for client1 using ip
@@ -193,8 +191,8 @@ class TestFuseAuthRejectAllow(DParentTest):
         self.is_vol_mounted = True
 
         # Unmount d1 from client2
-        redant.volume_unmount(subdir_volume_client2, self.mountpoint,
-                              self.client_list[1])
+        cmd = f"umount {self.mountpoint}"
+        redant.execute_abstract_op_node(cmd, self.client_list[1])
         self.is_vol_mounted = False
 
         # Setting auth.reject on d1 for client1 using hostname
@@ -223,6 +221,6 @@ class TestFuseAuthRejectAllow(DParentTest):
         self.is_vol_mounted = True
 
         # Unmount d1 from client2
-        redant.volume_unmount(subdir_volume_client2, self.mountpoint,
-                              self.client_list[1])
+        cmd = f"umount {self.mountpoint}"
+        redant.execute_abstract_op_node(cmd, self.client_list[1])
         self.is_vol_mounted = False

--- a/tests/functional/authentication/test_auth_reject_allow.py
+++ b/tests/functional/authentication/test_auth_reject_allow.py
@@ -1,135 +1,50 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-""" Description:
-        Test cases in this module tests the authentication allow feature
-        using auth.allow and auth.reject volume options
 """
-import copy
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
-                                                   runs_on)
-from glustolibs.gluster.glusterdir import mkdir
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.auth_ops import set_auth_allow, set_auth_reject
+ Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to check the authentication allow feature
+    using auth.allow and auth.reject volume options
+"""
+
+# disruptive;dist,rep,dist-rep,disp,dist-disp
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'], ['glusterfs']])
-class FuseAuthRejectAllow(GlusterBaseClass):
-    """
-    Tests to verify auth.reject and auth.allow volume options in volume and
-    sub-directory level on fuse mount.
-    """
-    @classmethod
-    def setUpClass(cls):
-        """
-        Create and start volume
-        """
-        cls.get_super_method(cls, 'setUpClass')()
-        # Create and start volume
-        ret = cls.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup "
-                                 "and start volume %s" % cls.volname)
+class TestFuseAuthRejectAllow(DParentTest):
 
-    def authenticated_mount(self, mount_obj):
-        """
-        Mount volume/sub-directory on authenticated client
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
+        # Check for 2 clients
+        if len(self.client_list) < 2:
+            self.TEST_RES = None
+            raise Exception("The test case require 2 clients to run the test")
 
-        Args:
-            mount_obj(obj): Object of GlusterMount class
-        """
-        # Mount volume
-        ret = mount_obj.mount()
-        self.assertTrue(ret, ("Failed to mount %s on client %s" %
-                              (mount_obj.volname,
-                               mount_obj.client_system)))
-        g.log.info("Successfully mounted %s on client %s", mount_obj.volname,
-                   mount_obj.client_system)
+        # Create and start the volume
+        conf_hash = self.vol_type_inf[self.volume_type]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots, force=True)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        for client in self.client_list:
+            self.redant.execute_abstract_op_node("mkdir -p "
+                                                 f"{self.mountpoint}",
+                                                 client)
 
-        # Verify mount
-        ret = mount_obj.is_mounted()
-        self.assertTrue(ret, ("%s is not mounted on client %s"
-                              % (mount_obj.volname, mount_obj.client_system)))
-        g.log.info("Verified: %s is mounted on client %s",
-                   mount_obj.volname, mount_obj.client_system)
-
-    def unauthenticated_mount(self, mount_obj):
-        """
-        Try to mount volume/sub-directoty on unauthenticated client
-        Args:
-            mount_obj(obj): Object of GlusterMount class
-        """
-        # Try to mount volume/sub-directory and verify
-        # Sometimes the mount command is returning exit code as 0 in case of
-        # mount failures as well.
-        # Hence not asserting while running mount command in test case.
-        # Instead asserting only if it is actually mounted.
-        # BZ 1590711
-        mount_obj.mount()
-
-        # Verify mount
-        ret = mount_obj.is_mounted()
-        if ret:
-            # Mount operation did not fail as expected. Cleanup the mount.
-            if not mount_obj.unmount():
-                g.log.error("Failed to unmount %s from client %s",
-                            mount_obj.volname, mount_obj.client_system)
-        self.assertFalse(ret, ("Mount operation did not fail as "
-                               "expected. Mount operation of "
-                               "%s on client %s passed. "
-                               "Mount point: %s"
-                               % (mount_obj.volname,
-                                  mount_obj.client_system,
-                                  mount_obj.mountpoint)))
-        g.log.info("Mount operation of %s on client %s failed as "
-                   "expected", mount_obj.volname, mount_obj.client_system)
-
-    def is_auth_failure(self, client_ip, previous_log_statement=''):
-        """
-        Check if the mount failure is due to authentication error
-        Args:
-            client_ip(str): IP of client in which mount failure has to be
-                verified.
-            previous_log_statement(str): AUTH_FAILED message of previous mount
-                failure due to auth error(if any). This is used to distinguish
-                between the current and previous message.
-        Return(str):
-            Latest AUTH_FAILED event log message.
-        """
-        # Command to find the log file
-        cmd = "ls /var/log/glusterfs/ -1t | head -1"
-        ret, out, _ = g.run(client_ip, cmd)
-        self.assertEqual(ret, 0, "Failed to find the log file.")
-
-        # Command to fetch latest AUTH_FAILED event log message.
-        cmd = "grep AUTH_FAILED /var/log/glusterfs/%s | tail -1" % out.strip()
-        ret, current_log_statement, _ = g.run(client_ip, cmd)
-        self.assertEqual(ret, 0, "Mount failure is not due to auth error")
-
-        # Check whether the AUTH_FAILED log is of the latest mount failure
-        self.assertNotEqual(current_log_statement.strip(),
-                            previous_log_statement,
-                            "Mount failure is not due to authentication "
-                            "error")
-        g.log.info("Mount operation has failed due to authentication error")
-        return current_log_statement.strip()
-
-    def test_auth_reject_allow(self):
+    def run_test(self, redant):
         """
         Verify auth.reject and auth.allow volume options in volume level using
         both client ip and hostname.
@@ -158,161 +73,127 @@ class FuseAuthRejectAllow(GlusterBaseClass):
         20. Set auth.allow on d1 for client2 using hostname of client2.
         21. Repeat steps 15 to 18.
         """
-        # pylint: disable = too-many-statements
         # Setting auth.reject on volume for client1 using ip
-        auth_dict = {'all': [self.mounts[0].client_system]}
-        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        auth_dict = {'all': [self.client_list[0]]}
+        if not redant.set_auth_reject(self.vol_name, self.server_list[0],
+                                      auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Setting auth.allow on volume for client2 using ip
-        auth_dict = {'all': [self.mounts[1].client_system]}
-        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        auth_dict = {'all': [self.client_list[1]]}
+        if not redant.set_auth_allow(self.vol_name, self.server_list[0],
+                                     auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Trying to mount volume on client1
-        self.unauthenticated_mount(self.mounts[0])
+        redant.unauthenticated_mount(self.vol_name, self.server_list[0],
+                                     self.mountpoint, self.client_list[0])
 
         # Verify whether mount failure on client1 is due to auth error
-        log_msg = self.is_auth_failure(self.mounts[0].client_system)
-        prev_log_statement = log_msg
+        prev_log_statement = redant.is_auth_failure(self.client_list[0])
 
         # Mounting volume on client2
-        self.authenticated_mount(self.mounts[1])
-
-        g.log.info("Verification of auth.reject and auth.allow options on "
-                   "volume using client IP is successful")
+        redant.authenticated_mount(self.vol_name, self.server_list[0],
+                                   self.mountpoint, self.client_list[1])
 
         # Unmount volume from client2
-        ret = self.mounts[1].unmount()
-        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
-                              % (self.volname, self.mounts[1].client_system)))
+        redant.volume_unmount(self.vol_name, self.mountpoint,
+                              self.client_list[1])
 
         # Obtain hostname of client1
-        ret, hostname_client1, _ = g.run(self.mounts[0].client_system,
-                                         "hostname")
-        self.assertEqual(ret, 0, ("Failed to obtain hostname of client %s"
-                                  % self.mounts[0].client_system))
-        g.log.info("Obtained hostname of client. IP- %s, hostname- %s",
-                   self.mounts[0].client_system, hostname_client1.strip())
+        ret = redant.execute_abstract_op_node("hostname", self.client_list[0])
+        hostname_client1 = ret['msg'][0].rstrip('\n')
 
         # Obtain hostname of client2
-        ret, hostname_client2, _ = g.run(self.mounts[1].client_system,
-                                         "hostname")
-        self.assertEqual(ret, 0, ("Failed to obtain hostname of client %s"
-                                  % self.mounts[1].client_system))
-        g.log.info("Obtained hostname of client. IP- %s, hostname- %s",
-                   self.mounts[1].client_system, hostname_client2.strip())
+        ret = redant.execute_abstract_op_node("hostname", self.client_list[1])
+        hostname_client2 = ret['msg'][0].rstrip('\n')
 
         # Setting auth.reject on volume for client1 using hostname
-        auth_dict = {'all': [hostname_client1.strip()]}
-        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        auth_dict = {'all': [hostname_client1]}
+        if not redant.set_auth_reject(self.vol_name, self.server_list[0],
+                                      auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Setting auth.allow on volume for client2 using hostname
-        auth_dict = {'all': [hostname_client2.strip()]}
-        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        auth_dict = {'all': [hostname_client2]}
+        if not redant.set_auth_allow(self.vol_name, self.server_list[0],
+                                     auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Trying to mount volume on client1
-        self.unauthenticated_mount(self.mounts[0])
+        redant.unauthenticated_mount(self.vol_name, self.server_list[0],
+                                     self.mountpoint, self.client_list[0])
 
         # Verify whether mount failure on client1 is due to auth error
-        log_msg = self.is_auth_failure(self.mounts[0].client_system,
-                                       prev_log_statement)
-        prev_log_statement = log_msg
+        prev_log_statement = redant.is_auth_failure(self.client_list[0],
+                                                    prev_log_statement)
 
         # Mounting volume on client2
-        self.authenticated_mount(self.mounts[1])
-
-        g.log.info("Verification of auth.reject and auth.allow options on "
-                   "volume using client hostname is successful")
+        redant.authenticated_mount(self.vol_name, self.server_list[0],
+                                   self.mountpoint, self.client_list[1])
 
         # Creating sub directory d1 on mounted volume
-        ret = mkdir(self.mounts[1].client_system, "%s/d1"
-                    % self.mounts[1].mountpoint)
-        self.assertTrue(ret, ("Failed to create directory 'd1' in volume %s "
-                              "from client %s"
-                              % (self.volname, self.mounts[1].client_system)))
+        redant.create_dir(self.mountpoint, "d1", self.client_list[1])
 
         # Unmount volume from client2
-        ret = self.mounts[1].unmount()
-        self.assertTrue(ret, ("Failed to unmount volume %s from client %s"
-                              % (self.volname, self.mounts[1].client_system)))
+        redant.volume_unmount(self.vol_name, self.mountpoint,
+                              self.client_list[1])
 
         # Setting auth.reject on d1 for client1 using ip
-        auth_dict = {'/d1': [self.mounts[0].client_system]}
-        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        auth_dict = {'/d1': [self.client_list[0]]}
+        if not redant.set_auth_reject(self.vol_name, self.server_list[0],
+                                      auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Setting auth.allow on d1 for client2 using ip
-        auth_dict = {'/d1': [self.mounts[1].client_system]}
-        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.allow volume option")
-
-        # Creating mount object for sub-directory mount on client1
-        mount_obj_client1 = copy.deepcopy(self.mounts[0])
-        mount_obj_client1.volname = "%s/d1" % self.volname
-
-        # Creating mount object for sub-directory mount on client2
-        mount_obj_client2 = copy.deepcopy(self.mounts[1])
-        mount_obj_client2.volname = "%s/d1" % self.volname
+        auth_dict = {'/d1': [self.client_list[1]]}
+        if not redant.set_auth_allow(self.vol_name, self.server_list[0],
+                                     auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Trying to mount d1 on client1
-        self.unauthenticated_mount(mount_obj_client1)
+        subdir_volume_client1 = f"{self.vol_name}/d1"
+        redant.unauthenticated_mount(subdir_volume_client1,
+                                     self.server_list[0], self.mountpoint,
+                                     self.client_list[0])
 
         # Verify whether mount failure on client1 is due to auth error
-        log_msg = self.is_auth_failure(mount_obj_client1.client_system,
-                                       prev_log_statement)
-        prev_log_statement = log_msg
+        prev_log_statement = redant.is_auth_failure(self.client_list[0],
+                                                    prev_log_statement)
 
         # Mounting d1 on client2
-        self.authenticated_mount(mount_obj_client2)
-
-        g.log.info("Verification of auth.reject and auth.allow options on "
-                   "sub-directory level using client IP is successful")
+        subdir_volume_client2 = f"{self.vol_name}/d1"
+        redant.authenticated_mount(subdir_volume_client2, self.server_list[0],
+                                   self.mountpoint, self.client_list[1])
 
         # Unmount d1 from client2
-        ret = mount_obj_client2.unmount()
-        self.assertTrue(ret, ("Failed to unmount %s from client %s"
-                              % (mount_obj_client2.volname,
-                                 mount_obj_client2.client_system)))
+        redant.volume_unmount(subdir_volume_client2, self.mountpoint,
+                              self.client_list[1])
 
         # Setting auth.reject on d1 for client1 using hostname
-        auth_dict = {'/d1': [hostname_client1.strip()]}
-        ret = set_auth_reject(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.reject volume option.")
+        auth_dict = {'/d1': [hostname_client1]}
+        if not redant.set_auth_reject(self.vol_name, self.server_list[0],
+                                      auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Setting auth.allow on d1 for client2 using hostname
-        auth_dict = {'/d1': [hostname_client2.strip()]}
-        ret = set_auth_allow(self.volname, self.mnode, auth_dict)
-        self.assertTrue(ret, "Failed to set auth.allow volume option")
+        auth_dict = {'/d1': [hostname_client2]}
+        if not redant.set_auth_allow(self.vol_name, self.server_list[0],
+                                     auth_dict):
+            raise Exception("Failed to set authentication")
 
         # Trying to mount d1 on client1
-        self.unauthenticated_mount(mount_obj_client1)
+        redant.unauthenticated_mount(subdir_volume_client1,
+                                     self.server_list[0], self.mountpoint,
+                                     self.client_list[0])
 
         # Verify whether mount failure on client1 is due to auth error
-        self.is_auth_failure(mount_obj_client1.client_system,
-                             prev_log_statement)
+        redant.is_auth_failure(self.client_list[0], prev_log_statement)
 
         # Mounting d1 on client2
-        self.authenticated_mount(mount_obj_client2)
-
-        g.log.info("Verification of auth.reject and auth.allow options on "
-                   "sub-directory level using client hostname is successful")
+        redant.authenticated_mount(subdir_volume_client2, self.server_list[0],
+                                   self.mountpoint, self.client_list[1])
 
         # Unmount d1 from client2
-        ret = mount_obj_client2.unmount()
-        self.assertTrue(ret, ("Failed to unmount %s from client %s"
-                              % (mount_obj_client2.volname,
-                                 mount_obj_client2.client_system)))
-
-    def tearDown(self):
-        """
-        Cleanup volume
-        """
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to cleanup volume.")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        redant.volume_unmount(subdir_volume_client2, self.mountpoint,
+                              self.client_list[1])


### PR DESCRIPTION
Migrated TC [test_auth_reject_allow](https://github.com/gluster/glusto-tests/blob/master/tests/functional/authentication/test_auth_reject_allow.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>