### PR TITLE
[Common] Adding view_snap_from_mount method

### DIFF
--- a/common/ops/gluster_ops/mount_ops.py
+++ b/common/ops/gluster_ops/mount_ops.py
@@ -232,3 +232,30 @@ class MountOps(AbstractOps):
             for client in snap_mnt_dict[snap].keys():
                 for mntpath in snap_mnt_dict[snap][client]:
                     self.unmount_snap(snap, mntpath, client)
+
+    def view_snap_from_mount(self, mounts_obj: list, snaps: list) -> bool:
+        """
+        Method to verify if the stated snaps are present under the .snaps
+        directory.
+
+        Args:
+            mount_obj (list): The mount_obj consists of client and mountpath
+            combination of dictionaries in a list.
+            snaps (list/str): List of snap names.
+
+        Returns:
+            bool: True if all the said snapnames in the snaps list are present
+            under the .snaps dir, else False.        
+        """
+        if not isinstance(snaps, list):
+            snaps = [snaps]
+
+        ret_list = []
+        for mountob in mounts_obj:
+            cmd = f'ls {mountob["mountpath"]}/.snaps/'
+            ret = self.execute_abstract_op_node(cmd, mountob["client"])
+            listing = [listval.strip() for listval in ret['msg']]
+            ret_list.append(listing)
+            if set(listing) != set(snaps):
+                return False
+        return True

--- a/common/ops/gluster_ops/mount_ops.py
+++ b/common/ops/gluster_ops/mount_ops.py
@@ -245,7 +245,7 @@ class MountOps(AbstractOps):
 
         Returns:
             bool: True if all the said snapnames in the snaps list are present
-            under the .snaps dir, else False.        
+            under the .snaps dir, else False.
         """
         if not isinstance(snaps, list):
             snaps = [snaps]

--- a/docs/BP/Ops/mount_ops.md
+++ b/docs/BP/Ops/mount_ops.md
@@ -54,6 +54,7 @@
             self.volume_unmount(volname, mount, mntd['client'], False)
 
 3) **is_mounted**<br>
+        
         This function checks if the volume is already mounted or not
         Args:
             1. volname (str): Name of volume to be checked
@@ -102,6 +103,19 @@
             else False.
 
         Example:
-
             ret = redant.wait_for_mountpoint_to_connect(self.mountpoint,
                                                         self.client_list[0])
+
+6) **view_snap_from_mount**<br>
+
+        This method verifies if the stated snaps are present under the .snaps directory.
+
+        Args:
+            mount_obj (dict): The mount_obj consists of client and mountpath combination of dirs in a list.
+            snaps (list/str): List of snap names or a snap name as str.
+
+        Return:
+            bool: True if all the said snapnames in the snaps list are present under the .snaps dir, else False.
+        
+        Example:
+            ret = redant.view_snap_from_mount(self.mountobj, self.snap_list)

--- a/tests/example/sample_component/test_snap_ops.py
+++ b/tests/example/sample_component/test_snap_ops.py
@@ -3,6 +3,7 @@ This file contains a test-case which tests
 the snapshot ops.
 """
 
+# disruptive;rep
 # disruptive;rep,dist,dist-rep,arb,dist-arb,disp,dist-disp
 
 
@@ -57,6 +58,8 @@ class TestCase(DParentTest):
         redant.logger.info(f"Snapd run status : {snap_running_status}")
         redant.snap_activate(self.snap_name, self.server_list[0],
                              force=True)
+        redant.snap_activate(self.snap_name2, self.server_list[0],
+                             force=True)
         redant.logger.info(redant.snap_list(self.server_list[0]))
         redant.logger.info(redant.get_snap_status(self.server_list[0]))
         snap_running_status = redant.is_snapd_running(self.vol_name,
@@ -74,7 +77,16 @@ class TestCase(DParentTest):
         redant.unmount_snap(self.snap_name, self.snap_mount,
                             self.client_list[0])
 
+        redant.enable_uss(self.vol_name, self.server_list[0])
+        self.mnt_list = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
+        self.snap_list = redant.get_snap_list(self.server_list[0],
+                                              self.vol_name)
+        if not redant.view_snap_from_mount(self.mnt_list,
+                                           self.snap_list):
+            raise Exception("Snap in .snaps doesn't match snap list provided")
+
         redant.snap_deactivate(self.snap_name, self.server_list[0])
+        redant.snap_deactivate(self.snap_name2, self.server_list[0])
         redant.logger.info(redant.get_snap_status_by_snapname(
             self.snap_name, self.server_list[0]))
         value_set = {"auto-delete": "disable"}

--- a/tests/example/sample_component/test_snap_ops.py
+++ b/tests/example/sample_component/test_snap_ops.py
@@ -3,7 +3,6 @@ This file contains a test-case which tests
 the snapshot ops.
 """
 
-# disruptive;rep
 # disruptive;rep,dist,dist-rep,arb,dist-arb,disp,dist-disp
 
 
@@ -22,11 +21,12 @@ class TestCase(DParentTest):
         1. Creation of snapshot
         2. Getting info and status
         3. Setting a config option
-        4. Activating snap and checking info and status
+        4. Activating snaps and checking info and status
         5. Mounting the snap
         6. Perform listing inside the snap mount
         7. Unmount the snapshot
-        8. Deactivate the snapshot
+        8. Check if the activated snaps are accessible under .snaps
+        8. Deactivate the snaps
         9. Check status and info
         10. Disabling the config option
         11. Deletion of snapshot


### PR DESCRIPTION
### All Submissions:

Desciption: Added the method view_snap_from_mount. With this in place, we can check whether the .snaps under the mount dir contains the said list of snaps or not.


Fixes: #875



<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
