### PR TITLE
[Core] Handling standalone exclude output

### DIFF
--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -374,6 +374,11 @@ def handle_results(resultQueue, totalTime: float, filePath: str = None):
     # Obtain the statistics for further use.
     statDict = _obtain_stat(resultDict)
 
+    # Check for exclude test run.
+    if statDict == {'Total': {}}:
+        print("Requested test is in exclude list.")
+        return 
+
     # Convert the pass values to percentage.
     statDict = _transform_to_percent(statDict)
 

--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -377,7 +377,7 @@ def handle_results(resultQueue, totalTime: float, filePath: str = None):
     # Check for exclude test run.
     if statDict == {'Total': {}}:
         print("Requested test is in exclude list.")
-        return 
+        return
 
     # Convert the pass values to percentage.
     statDict = _transform_to_percent(statDict)


### PR DESCRIPTION
When a single test run is performed for a test
case which is in exclude list, the result handler
throws an exception when the statDict comes out
to be empty.

Added a check specifically for exclude cases.

Fixes: #879

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>




<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
