### PR TITLE
[Core] Exclude test path check

### DIFF
--- a/core/parsing/params_handler.py
+++ b/core/parsing/params_handler.py
@@ -3,6 +3,7 @@ This module contains one class - ParamsHandler,
 which contains APIs for configuration parameter
 parsing.
 """
+import os
 from parsing.test_parser import Parser
 
 
@@ -159,10 +160,17 @@ class ParamsHandler:
             brick_roots[server] = self.server_config[server]['brick_root']
         return brick_roots
 
-    def get_excluded_tests(self):
+    def get_excluded_tests(self) -> tuple:
         """
         Gets a list of exluded tests from the config file.
         Returns:
-            list : list of exluded tests
+            tuple: With first value being the list of paths and second
+            value being boolean which indicates whether the exclude list
+            is valid or not.
         """
-        return self.config_hashmap.get("excluded_tests", [])
+        ret = self.config_hashmap.get("excluded_tests", [])
+        for paths in ret:
+            if not os.path.isfile(paths):
+                return ([], False)
+
+        return (ret, True)

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -86,7 +86,12 @@ def main():
 
     spinner.start("Building test list")
     # Building the test list and obtaining the TC details.
-    excluded_tests = param_obj.get_excluded_tests()
+    excluded_result = param_obj.get_excluded_tests()
+    if not excluded_result[1]:
+        spinner.fail("error in exclude list. Invalid path present")
+        sys.exit(1)
+
+    excluded_tests = excluded_result[0]
     spec_test = (args.test_dir.endswith(".py")
                  and args.test_dir.split("/")[-1].startswith("test"))
     try:

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -88,7 +88,7 @@ def main():
     # Building the test list and obtaining the TC details.
     excluded_result = param_obj.get_excluded_tests()
     if not excluded_result[1]:
-        spinner.fail("error in exclude list. Invalid path present")
+        spinner.fail("Error in exclude list. Invalid path present")
         sys.exit(1)
 
     excluded_tests = excluded_result[0]


### PR DESCRIPTION
Added check if the exclude test paths are valid.
If there is even a single invalid path, it is a cause
of worry and hence the framework will spit that out
as an error.

Updates: #698

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
