### PR TITLE
[Common] Snap clone environ changes

### DIFF
--- a/common/ops/gluster_ops/snapshot_ops.py
+++ b/common/ops/gluster_ops/snapshot_ops.py
@@ -234,13 +234,28 @@ class SnapshotOps(AbstractOps):
         if not excep and ret['msg']['opRet'] != '0':
             return ret
 
-        # Query the vol info for clonename
+        # Query the vol info for brick and vol param data.
+        brick_data = {}
+        ret = self.get_volume_info(node, clonename)
+        for brick in ret[clonename]['bricks']:
+            ip, brick_path = brick['name'].split(':')
+            if ip not in brick_data.keys():
+                brick_data[ip] = []
+            brick_data[ip].append(brick_path)
 
-        # Parse the brick info
-
-        # Obtain the volume params
+        # build the volume params for cloned volume.
+        vol_param = {}
+        vol_param["dist_count"] = ret[clonename]["distCount"]
+        vol_param["replica_count"] = ret[clonename]["replicaCount"]
+        vol_param["disperse_count"] = ret[clonename]["disperseCount"]
+        vol_param["arbiter_count"] = ret[clonename]["arbiterCount"]
+        vol_param["redundancy_count"] = ret[clonename]["redundancyCount"]
+        vol_param["transport"] = "tcp"
 
         # create environ data
+        self.es.set_new_volume(clonename, brick_data)
+        self.es.set_vol_type(clonename, vol_param)
+
         return ret
 
     def snap_restore(self, snapname: str, node: str,

--- a/common/ops/gluster_ops/snapshot_ops.py
+++ b/common/ops/gluster_ops/snapshot_ops.py
@@ -230,7 +230,18 @@ class SnapshotOps(AbstractOps):
         """
         cmd = (f"gluster snapshot clone {clonename} {snapname} --mode=script"
                " --xml")
-        return self.execute_abstract_op_node(cmd, node, excep)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
+        if not excep and ret['msg']['opRet'] != '0':
+            return ret
+
+        # Query the vol info for clonename
+
+        # Parse the brick info
+
+        # Obtain the volume params
+
+        # create environ data
+        return ret
 
     def snap_restore(self, snapname: str, node: str,
                      excep: bool = True) -> bool:

--- a/tests/example/sample_component/test_snap_ops.py
+++ b/tests/example/sample_component/test_snap_ops.py
@@ -3,6 +3,7 @@ This file contains a test-case which tests
 the snapshot ops.
 """
 
+# disruptive;rep
 # disruptive;rep,dist,dist-rep,arb,dist-arb,disp,dist-disp
 
 
@@ -60,6 +61,15 @@ class TestCase(DParentTest):
                              force=True)
         redant.snap_activate(self.snap_name2, self.server_list[0],
                              force=True)
+
+        vol_list = redant.get_volume_list(self.server_list[0])
+        #print(vol_list)
+        redant.snap_clone(self.snap_name, "clone1", self.server_list[0])
+        vol_list = redant.get_volume_list(self.server_list[0])
+        #print(vol_list)
+        vol_info = redant.get_volume_info(self.server_list[0])
+        #print(vol_info)
+        
         redant.logger.info(redant.snap_list(self.server_list[0]))
         redant.logger.info(redant.get_snap_status(self.server_list[0]))
         snap_running_status = redant.is_snapd_running(self.vol_name,

--- a/tests/example/sample_component/test_snap_ops.py
+++ b/tests/example/sample_component/test_snap_ops.py
@@ -3,7 +3,6 @@ This file contains a test-case which tests
 the snapshot ops.
 """
 
-# disruptive;rep
 # disruptive;rep,dist,dist-rep,arb,dist-arb,disp,dist-disp
 
 

--- a/tests/example/sample_component/test_snap_ops.py
+++ b/tests/example/sample_component/test_snap_ops.py
@@ -62,14 +62,7 @@ class TestCase(DParentTest):
         redant.snap_activate(self.snap_name2, self.server_list[0],
                              force=True)
 
-        vol_list = redant.get_volume_list(self.server_list[0])
-        #print(vol_list)
         redant.snap_clone(self.snap_name, "clone1", self.server_list[0])
-        vol_list = redant.get_volume_list(self.server_list[0])
-        #print(vol_list)
-        vol_info = redant.get_volume_info(self.server_list[0])
-        #print(vol_info)
-        
         redant.logger.info(redant.snap_list(self.server_list[0]))
         redant.logger.info(redant.get_snap_status(self.server_list[0]))
         snap_running_status = redant.is_snapd_running(self.vol_name,


### PR DESCRIPTION
Snapshot cloning creates a volume from the snapshot. Now from redant perspective,
the volume data needs to be tracked by environ, which is exactly the purpose of this
patch, to add the volume data to environ if clone succeeds.

Fixes: #887

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
