### PR TITLE
[Core] Fixing argument order

### DIFF
--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -139,8 +139,8 @@ def main():
     if args.excel_sheet is None:
         handle_results(result_queue, total_time, logger_obj)
     else:
-        handle_results(result_queue, total_time, args.excel_sheet,
-                       logger_obj)
+        handle_results(result_queue, total_time, logger_obj,
+                       args.excel_sheet)
 
     logger_obj.debug("Starting env teardown.")
     env_set.teardown_env()


### PR DESCRIPTION
The logger_obj has to be the 3rd argument instead of 4th argument.

Fixes: #938

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
