### PR TITLE
[Common] Preventing ssh hang in command execution

### DIFF
--- a/common/rexe.py
+++ b/common/rexe.py
@@ -291,7 +291,8 @@ class Rexe:
         Arg:
             node (str)
         """
-        cmd = f'ssh -t root@{node} "reboot > /dev/null 2>&1;" > /dev/null 2>&1;'
+        cmd = (f'ssh -t root@{node} "sleep 1;reboot > /dev/null 2>&1;"'
+               ' > /dev/null 2>&1;')
         self.logger.info(f"Executing the command : {cmd}")
         ret = os.system(cmd)
         self.logger.info(f"Return value for the command {cmd} is {ret}")

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -291,7 +291,7 @@ class Rexe:
         Arg:
             node (str)
         """
-        cmd = f'ssh -t root@{node} "reboot" > /dev/null 2>&1'
+        cmd = f'ssh -t root@{node} "reboot > /dev/null 2>&1;" > /dev/null 2>&1;'
         self.logger.info(f"Executing the command : {cmd}")
         ret = os.system(cmd)
         self.logger.info(f"Return value for the command {cmd} is {ret}")


### PR DESCRIPTION
When a remote command is executed with the help of
ssh, the command is treated as a process at the
remote machine. Hence host system will wait at the
ssh command till the process ends at the remote machine.

If for some reason, the process doesn't end or if
the ssh still thinks that the process hasn't ended,
the flow will be hung at the ssh command.

Fixes: #940

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>



<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
