### PR TITLE
[testMigration] Migrating test_uss_brick_down.py

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -1020,6 +1020,9 @@ class BrickOps(AbstractOps):
         if not isinstance(brick_list, list):
             brick_list = [brick_list]
 
+        if not isinstance(server_list, list):
+            server_list = [server_list]
+
         if not disrup_method:
             self.logger.info(f"Getting bricks {brick_list} online by forced"
                              f" volume start of {volname}")

--- a/core/runner_thread.py
+++ b/core/runner_thread.py
@@ -33,7 +33,7 @@ class RunnerThread:
             tb = traceback.format_exc()
             self.logger.error(f"{self.tname} : {error}")
             self.logger.error(f"{self.tname}: {tb}")
-            self.test_stats['testResult'] = False
+            self.test_stats['testResult'] = [False]
             self.skip_run_thread = True
 
     def run_thread(self):
@@ -54,5 +54,5 @@ class RunnerThread:
             tb = traceback.format_exc()
             self.logger.error(f"{self.tname} : {error}")
             self.logger.error(f"{self.tname} : {tb}")
-            self.test_stats['testResult'] = False
+            self.test_stats['testResult'] = [False]
         return self.test_stats

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -48,11 +48,9 @@ class SnapUssBrickDown(GlusterBaseClass):
         # Upload io scripts for running IO on mounts
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                   "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, script_local_path)
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts "
                                  "to clients ")

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -1,0 +1,202 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+    This test case will validate USS behaviour when we
+    enable USS on the volume when brick is down.
+"""
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.gluster_base_class import runs_on
+from glustolibs.io.utils import validate_io_procs
+from glustolibs.gluster.snap_ops import (snap_create, snap_delete_all,
+                                         get_snap_list, snap_activate)
+from glustolibs.gluster.uss_ops import (enable_uss, is_uss_enabled,
+                                        uss_list_snaps, disable_uss)
+from glustolibs.gluster.brick_libs import get_all_bricks, bring_bricks_offline
+from glustolibs.gluster.volume_ops import volume_start
+from glustolibs.misc.misc_libs import upload_scripts
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed', 'distributed-dispersed'],
+          ['glusterfs', 'nfs', 'cifs']])
+class SnapUssBrickDown(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+        # Upload io scripts for running IO on mounts
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", cls.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts "
+                                 "to clients ")
+        g.log.info("Successfully uploaded IO scripts to clients %s")
+
+    def setUp(self):
+
+        # SettingUp and Mounting the volume
+        GlusterBaseClass.setUp.im_func(self)
+        g.log.info("Starting to SetUp Volume and mount volume")
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume %s" % self.volname)
+        g.log.info("Volume %s has been setup successfully", self.volname)
+
+    def tearDown(self):
+
+        # Deleting all snapshot
+        g.log.info("Deleting all snapshots created")
+        ret, _, _ = snap_delete_all(self.mnode)
+        if ret != 0:
+            raise ExecutionError("Snapshot Delete Failed")
+        g.log.info("Successfully deleted all snapshots")
+
+        # Disable uss for volume
+        g.log.info("Disabling uss for volume")
+        ret, _, _ = disable_uss(self.mnode, self.volname)
+        if ret != 0:
+            raise ExecutionError("Failed to disable uss")
+        g.log.info("Successfully disabled uss for volume"
+                   "%s", self.volname)
+
+        # Unmount and cleanup original volume
+        g.log.info("Starting to Unmount and Cleanup Volume")
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to umount and cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
+
+    def test_uss_brick_down(self):
+
+        # pylint: disable=too-many-statements
+        """
+        Steps:
+        * Create volume
+        * Mount volume
+        * Perform I/O on mounts
+        * Bring down one brick
+        * Enbale USS
+        * Validate USS is enabled
+        * Bring the brick online using gluster v start force
+        * Create 2 snapshots snapy1 & snapy2
+        * Validate snap created
+        * Activate snapy1 & snapy2
+        * List snaps under .snap directory
+          -- snap1 and snap2 should be listed under .snaps
+        """
+
+        # Perform I/O
+        g.log.info("Starting IO on all mounts...")
+        self.counter = 1
+        self.all_mounts_procs = []
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dirname-start-num %d "
+                   "--dir-depth 2 "
+                   "--dir-length 2 "
+                   "--max-num-of-dirs 2 "
+                   "--num-of-files 2 %s" % (self.script_upload_path,
+                                            self.counter,
+                                            mount_obj.mountpoint))
+
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+        self.io_validation_complete = False
+
+        # Validate IO
+        g.log.info("Wait for IO to complete and validate IO ...")
+        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
+        self.assertTrue(ret, "IO failed on some of the clients")
+        self.io_validation_complete = True
+        g.log.info("I/O successful on clients")
+
+        # Bring down 1 brick from brick list
+        g.log.info("Getting all the bricks of the volume")
+        bricks_list = get_all_bricks(self.mnode, self.volname)
+        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
+        g.log.info("Successfully got the list of bricks of volume")
+
+        ret = bring_bricks_offline(self.volname, bricks_list[0])
+        self.assertTrue(ret, ("Failed to bring down the brick %s ",
+                              bricks_list[0]))
+        g.log.info("Successfully brought the brick %s down", bricks_list[0])
+
+        # Enable USS
+        g.log.info("Enable USS on volume")
+        ret, _, _ = enable_uss(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to enable USS on volume")
+        g.log.info("Successfully enabled USS on volume")
+
+        # Validate USS is enabled
+        g.log.info("Validating USS is enabled")
+        ret = is_uss_enabled(self.mnode, self.volname)
+        self.assertTrue(ret, "USS is disabled on volume "
+                        "%s" % self.volname)
+        g.log.info("USS enabled on volume %s", self.volname)
+
+        #  Bring the brick online using gluster v start force
+        g.log.info("Bring the brick online using gluster v start force")
+        ret, _, _ = volume_start(self.mnode, self.volname, force=True)
+        self.assertEqual(ret, 0, "Volume start with force failed")
+        g.log.info("Volume start with force successfull")
+
+        # Create 2 snapshot
+        g.log.info("Creating 2 snapshots for volume %s", self.volname)
+        for i in range(0, 2):
+            ret, _, _ = snap_create(self.mnode, self.volname, "snapy%s" % i)
+            self.assertEqual(ret, 0, ("Failed to create snapshot for %s"
+                                      % self.volname))
+            g.log.info("Snapshot %s created successfully for volume  %s",
+                       "snapy%s" % i, self.volname)
+
+        # Check for no of snaps using snap_list it should be 2 now
+        snap_list = get_snap_list(self.mnode)
+        self.assertEqual(2, len(snap_list), "No of snaps not consistent "
+                         "for volume %s" % self.volname)
+        g.log.info("Successfully validated number of snaps.")
+
+        # Activate snapshot snapy1 & snapy2
+        g.log.info("Activating snapshot snapy1 & snapy2")
+        for i in range(0, 2):
+            ret, _, _ = snap_activate(self.mnode, "snapy%s" % i)
+            self.assertEqual(ret, 0, "Failed to activate snapshot snapy%s" % i)
+        g.log.info("Both snapshots activated successfully")
+
+        # list activated snapshots directory under .snaps
+        g.log.info("Listing activated snapshots under .snaps")
+        for mount_obj in self.mounts:
+            ret, out, _ = uss_list_snaps(mount_obj.client_system,
+                                         mount_obj.mountpoint)
+            self.assertEqual(ret, 0, "Directory Listing Failed for"
+                             " Activated Snapshot")
+            validate_dir = out.split('\n')
+            for i in range(0, 2):
+                self.assertIn("snapy%s" % i, validate_dir, "Failed to "
+                              "validate snapy%s under .snaps directory")
+                g.log.info("Activated Snapshot snapy%s listed Successfully", i)

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -130,11 +130,11 @@ class SnapUssBrickDown(GlusterBaseClass):
         self.io_validation_complete = False
 
         # Validate IO
-        g.log.info("Wait for IO to complete and validate IO ...")
-        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
-        self.assertTrue(ret, "IO failed on some of the clients")
+        self.assertTrue(
+            validate_io_procs(self.all_mounts_procs, self.mounts),
+            "IO failed on some of the clients"
+        )
         self.io_validation_complete = True
-        g.log.info("I/O successful on clients")
 
         # Bring down 1 brick from brick list
         g.log.info("Getting all the bricks of the volume")

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -20,7 +20,10 @@ Description:
     enable USS on the volume when brick is down.
 """
 
+import sys
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass
 from glustolibs.gluster.gluster_base_class import runs_on
@@ -41,7 +44,7 @@ class SnapUssBrickDown(GlusterBaseClass):
 
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         # Upload io scripts for running IO on mounts
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
@@ -58,7 +61,7 @@ class SnapUssBrickDown(GlusterBaseClass):
     def setUp(self):
 
         # SettingUp and Mounting the volume
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         g.log.info("Starting to SetUp Volume and mount volume")
         ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
         if not ret:
@@ -115,14 +118,14 @@ class SnapUssBrickDown(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
-                   "--num-of-files 2 %s" % (self.script_upload_path,
-                                            self.counter,
-                                            mount_obj.mountpoint))
+                   "--num-of-files 2 %s" % (
+                       sys.version_info.major, self.script_upload_path,
+                       self.counter, mount_obj.mountpoint))
 
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -98,7 +98,7 @@ class SnapUssBrickDown(GlusterBaseClass):
         * Mount volume
         * Perform I/O on mounts
         * Bring down one brick
-        * Enbale USS
+        * Enable USS
         * Validate USS is enabled
         * Bring the brick online using gluster v start force
         * Create 2 snapshots snapy1 & snapy2
@@ -164,7 +164,7 @@ class SnapUssBrickDown(GlusterBaseClass):
         g.log.info("Bring the brick online using gluster v start force")
         ret, _, _ = volume_start(self.mnode, self.volname, force=True)
         self.assertEqual(ret, 0, "Volume start with force failed")
-        g.log.info("Volume start with force successfull")
+        g.log.info("Volume start with force successful")
 
         # Create 2 snapshot
         g.log.info("Creating 2 snapshots for volume %s", self.volname)

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@ Description:
     enable USS on the volume when brick is down.
 """
 
-import sys
 
 from glusto.core import Glusto as g
 
@@ -116,13 +115,13 @@ class SnapUssBrickDown(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
                    "--num-of-files 2 %s" % (
-                       sys.version_info.major, self.script_upload_path,
+                       self.script_upload_path,
                        self.counter, mount_obj.mountpoint))
 
             proc = g.run_async(mount_obj.client_system, cmd,

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -1,97 +1,48 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
+  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 Description:
     This test case will validate USS behaviour when we
     enable USS on the volume when brick is down.
 """
 
+# disruptive;rep,dist-rep,disp,dist,dist-disp
+# TODO NFS and CIFS
 
-from glusto.core import Glusto as g
-
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.gluster_base_class import runs_on
-from glustolibs.io.utils import validate_io_procs
-from glustolibs.gluster.snap_ops import (snap_create, snap_delete_all,
-                                         get_snap_list, snap_activate)
-from glustolibs.gluster.uss_ops import (enable_uss, is_uss_enabled,
-                                        uss_list_snaps, disable_uss)
-from glustolibs.gluster.brick_libs import get_all_bricks, bring_bricks_offline
-from glustolibs.gluster.volume_ops import volume_start
-from glustolibs.misc.misc_libs import upload_scripts
+import traceback
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed', 'distributed-dispersed'],
-          ['glusterfs', 'nfs', 'cifs']])
-class SnapUssBrickDown(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-        # Upload io scripts for running IO on mounts
-        g.log.info("Upload io scripts to clients %s for running IO on "
-                   "mounts", cls.clients)
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts "
-                                 "to clients ")
-        g.log.info("Successfully uploaded IO scripts to clients %s")
+    def terminate(self):
+        try:
+            ret = self.redant.wait_for_io_to_complete(self.all_mounts_procs,
+                                                      self.mounts)
+            if not ret:
+                raise Exception("IO failed on some of the clients")
+        except Exception as e:
+            tb = traceback.format_exc()
+            self.redant.logger.error(e)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-    def setUp(self):
+    def run_test(self, redant):
 
-        # SettingUp and Mounting the volume
-        self.get_super_method(self, 'setUp')()
-        g.log.info("Starting to SetUp Volume and mount volume")
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to setup volume %s" % self.volname)
-        g.log.info("Volume %s has been setup successfully", self.volname)
-
-    def tearDown(self):
-
-        # Deleting all snapshot
-        g.log.info("Deleting all snapshots created")
-        ret, _, _ = snap_delete_all(self.mnode)
-        if ret != 0:
-            raise ExecutionError("Snapshot Delete Failed")
-        g.log.info("Successfully deleted all snapshots")
-
-        # Disable uss for volume
-        g.log.info("Disabling uss for volume")
-        ret, _, _ = disable_uss(self.mnode, self.volname)
-        if ret != 0:
-            raise ExecutionError("Failed to disable uss")
-        g.log.info("Successfully disabled uss for volume"
-                   "%s", self.volname)
-
-        # Unmount and cleanup original volume
-        g.log.info("Starting to Unmount and Cleanup Volume")
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to umount and cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-    def test_uss_brick_down(self):
-
-        # pylint: disable=too-many-statements
         """
         Steps:
         * Create volume
@@ -109,94 +60,63 @@ class SnapUssBrickDown(GlusterBaseClass):
         """
 
         # Perform I/O
-        g.log.info("Starting IO on all mounts...")
-        self.counter = 1
+        redant.logger.info("Starting IO on all mounts...")
+        counter = 1
         self.all_mounts_procs = []
-        for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dirname-start-num %d "
-                   "--dir-depth 2 "
-                   "--dir-length 2 "
-                   "--max-num-of-dirs 2 "
-                   "--num-of-files 2 %s" % (
-                       self.script_upload_path,
-                       self.counter, mount_obj.mountpoint))
+        self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
 
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
+        for mount in self.mounts:
+            redant.logger.info(f"Starting IO on {mount['client']}:"
+                               f"{mount['mountpath']}")
+            proc = redant.create_deep_dirs_with_files(mount['mountpath'],
+                                                      counter, 2, 3, 4, 10,
+                                                      mount['client'])
             self.all_mounts_procs.append(proc)
-        self.io_validation_complete = False
+            counter += 10
 
-        # Validate IO
-        self.assertTrue(
-            validate_io_procs(self.all_mounts_procs, self.mounts),
-            "IO failed on some of the clients"
-        )
-        self.io_validation_complete = True
+        # Check async command status.
+        for async_job in self.all_mounts_procs:
+            if redant.check_async_command_status(async_job):
+                raise Exception("IO shouldn't have ended.")
 
         # Bring down 1 brick from brick list
-        g.log.info("Getting all the bricks of the volume")
-        bricks_list = get_all_bricks(self.mnode, self.volname)
-        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
-        g.log.info("Successfully got the list of bricks of volume")
-
-        ret = bring_bricks_offline(self.volname, bricks_list[0])
-        self.assertTrue(ret, ("Failed to bring down the brick %s ",
-                              bricks_list[0]))
-        g.log.info("Successfully brought the brick %s down", bricks_list[0])
+        bricks_list = redant.get_online_bricks_list(self.vol_name,
+                                                    self.server_list[0])
+        redant.bring_bricks_offline(self.vol_name, [bricks_list[1]])
+        if not redant.are_bricks_offline(self.vol_name,
+                                         [bricks_list[1]],
+                                         self.server_list[0]):
+            raise Exception(f"Brick {bricks_list[1]} is not offline")
 
         # Enable USS
-        g.log.info("Enable USS on volume")
-        ret, _, _ = enable_uss(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to enable USS on volume")
-        g.log.info("Successfully enabled USS on volume")
+        redant.enable_uss(self.vol_name, self.server_list[0])
 
         # Validate USS is enabled
-        g.log.info("Validating USS is enabled")
-        ret = is_uss_enabled(self.mnode, self.volname)
-        self.assertTrue(ret, "USS is disabled on volume "
-                        "%s" % self.volname)
-        g.log.info("USS enabled on volume %s", self.volname)
+        if not redant.is_uss_enabled(self.vol_name, self.server_list[0]):
+            raise Exception("USS is not enabled.")
 
         #  Bring the brick online using gluster v start force
-        g.log.info("Bring the brick online using gluster v start force")
-        ret, _, _ = volume_start(self.mnode, self.volname, force=True)
-        self.assertEqual(ret, 0, "Volume start with force failed")
-        g.log.info("Volume start with force successful")
+        if not redant.bring_bricks_online(self.vol_name, self.server_list,
+                                          bricks_list[1]):
+            raise Exception(f"Couldn't bring {bricks_list[1]} online")
 
         # Create 2 snapshot
-        g.log.info("Creating 2 snapshots for volume %s", self.volname)
         for i in range(0, 2):
-            ret, _, _ = snap_create(self.mnode, self.volname, "snapy%s" % i)
-            self.assertEqual(ret, 0, ("Failed to create snapshot for %s"
-                                      % self.volname))
-            g.log.info("Snapshot %s created successfully for volume  %s",
-                       "snapy%s" % i, self.volname)
+            snap_name = f"{self.vol_name}-snap{i}"
+            redant.snap_create(self.vol_name, snap_name,
+                               self.server_list[0])
 
         # Check for no of snaps using snap_list it should be 2 now
-        snap_list = get_snap_list(self.mnode)
-        self.assertEqual(2, len(snap_list), "No of snaps not consistent "
-                         "for volume %s" % self.volname)
-        g.log.info("Successfully validated number of snaps.")
+        snap_list = redant.get_snap_list(self.server_list[0], self.vol_name)
+        if len(snap_list) != 2:
+            raise Exception("Snap list should have 2 snap volumes. But instead"
+                            f" is {snap_list}")
 
         # Activate snapshot snapy1 & snapy2
-        g.log.info("Activating snapshot snapy1 & snapy2")
         for i in range(0, 2):
-            ret, _, _ = snap_activate(self.mnode, "snapy%s" % i)
-            self.assertEqual(ret, 0, "Failed to activate snapshot snapy%s" % i)
-        g.log.info("Both snapshots activated successfully")
+            snap_name = f"{self.vol_name}-snap{i}"
+            redant.snap_activate(snap_name, self.server_list[0])
 
-        # list activated snapshots directory under .snaps
-        g.log.info("Listing activated snapshots under .snaps")
-        for mount_obj in self.mounts:
-            ret, out, _ = uss_list_snaps(mount_obj.client_system,
-                                         mount_obj.mountpoint)
-            self.assertEqual(ret, 0, "Directory Listing Failed for"
-                             " Activated Snapshot")
-            validate_dir = out.split('\n')
-            for i in range(0, 2):
-                self.assertIn("snapy%s" % i, validate_dir, "Failed to "
-                              "validate snapy%s under .snaps directory")
-                g.log.info("Activated Snapshot snapy%s listed Successfully", i)
+        # Validate if all snaps are listed under .snaps
+        if not redant.view_snap_from_mount(self.mounts, snap_list):
+            raise Exception("Snap in .snaps doesn't match snap list provided")

--- a/tests/functional/snapshot/test_uss_brick_down.py
+++ b/tests/functional/snapshot/test_uss_brick_down.py
@@ -52,11 +52,10 @@ class TestCase(DParentTest):
         * Enable USS
         * Validate USS is enabled
         * Bring the brick online using gluster v start force
-        * Create 2 snapshots snapy1 & snapy2
+        * Create 2 snapshots.
         * Validate snap created
-        * Activate snapy1 & snapy2
-        * List snaps under .snap directory
-          -- snap1 and snap2 should be listed under .snaps
+        * Activate both the snapshots.
+        * Validate whether both the snapshots are listed under .snaps
         """
 
         # Perform I/O
@@ -112,7 +111,7 @@ class TestCase(DParentTest):
             raise Exception("Snap list should have 2 snap volumes. But instead"
                             f" is {snap_list}")
 
-        # Activate snapshot snapy1 & snapy2
+        # Activate the snapshots
         for i in range(0, 2):
             snap_name = f"{self.vol_name}-snap{i}"
             redant.snap_activate(snap_name, self.server_list[0])

--- a/tools/linting.sh
+++ b/tools/linting.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Flake runs
-printf "Flake runs"
+printf "Flake runs\n"
 flake8 $(pwd) --ignore=C901,F811,F841,E722,E226,E402,W503,W605 --count --select=E9,F63,F7,F82 --show-source --statistics
 flake8 $(pwd) --ignore=C901,F811,F841,E722,E226,E402,W503,W605 --count --max-complexity=10 --max-line-length=79 --statistics
 

--- a/tools/linting.sh
+++ b/tools/linting.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
 # Flake runs
+printf "Flake runs"
 flake8 $(pwd) --ignore=C901,F811,F841,E722,E226,E402,W503,W605 --count --select=E9,F63,F7,F82 --show-source --statistics
 flake8 $(pwd) --ignore=C901,F811,F841,E722,E226,E402,W503,W605 --count --max-complexity=10 --max-line-length=79 --statistics
 
 # Pylint runs
+printf "Pylint result for core dir"
 pylint --rcfile=$(pwd)/.pylintrc $(pwd)/core/
+
+printf "Pylint result for common dir"
 pylint --rcfile=$(pwd)/.pylintrc $(pwd)/common/
+
+printf "Pylint result for tests dir"
 pylint --rcfile=$(pwd)/.pylintrc $(pwd)/tests/


### PR DESCRIPTION
Migrating the test [test_uss_brick_down.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/snapshot/test_uss_brick_down.py)

Also fixing the test_stat handling in runner_thread and making the lint tool a little more descriptive in output.

Updates: #292 

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>