### PR TITLE
Remove stripCount variable from volume options

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -857,7 +857,6 @@ class VolumeOps(AbstractOps):
                             'typeStr': 'Disperse',
                             'replicaCount': '1',
                             'arbiterCount': '0',
-                            'stripeCount': '1',
                             'disperseCount': '3',
                             'redundancyCount': '1'
                         }
@@ -877,7 +876,6 @@ class VolumeOps(AbstractOps):
             'typeStr': '',
             'replicaCount': '',
             'arbiterCount': '',
-            'stripeCount': '',
             'disperseCount': '',
             'redundancyCount': ''
         }


### PR DESCRIPTION
stripCount is not used for any vol types and its
deprecated from gluster too

Removing it will also remove unnecessary logs errors
[2021-08-20 09:45:13,065] ERROR  - Unable to find key stripeCount
in the volume info for the volume test_no_glustershd_with_distribute-dist

Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>