### PR TITLE
Added flag for clearing gluster logs

### DIFF
--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -401,3 +401,23 @@ class MachineOps(AbstractOps):
                     self.TEST_RES[0] = None
                     raise Exception(f"The test case requires {bricks_count}"
                                     " bricks per node to run the test")
+
+    def delete_glusterfs_logs(self, server_list: list, client_list: list):
+        """
+        Delete all the log files under '/var/logs/glusterfs/' directory
+
+        Args:
+            server_list (list): List of servers
+            client_list (list): List of clients
+        """
+        if not isinstance(server_list, list):
+            server_list = [server_list]
+        if not isinstance(client_list, list):
+            client_list = [client_list]
+
+        total_nodes = server_list + client_list
+        self.logger.debug("Clearing old glusterfs logs on the nodes: "
+                          f"{total_nodes}")
+        for node in total_nodes:
+            cmd = "rm -rf /var/log/glusterfs/*"
+            self.execute_abstract_op_node(cmd, node, False)

--- a/core/environ.py
+++ b/core/environ.py
@@ -123,7 +123,7 @@ class environ:
             self.redant.execute_abstract_op_multinode(cmd,
                                                       arequal_machines)
 
-    def setup_env(self):
+    def setup_env(self, clear_logs):
         """
         Setting up of the environment before the TC execution begins.
         """
@@ -131,6 +131,9 @@ class environ:
         self.spinner.start("Setting up environment")
         self.redant.hard_terminate(self.server_list, self.client_list,
                                    self.brick_root)
+        if clear_logs:
+            self.redant.delete_glusterfs_logs(self.server_list,
+                                              self.client_list)
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)

--- a/core/environ.py
+++ b/core/environ.py
@@ -131,9 +131,14 @@ class environ:
         self.spinner.start("Setting up environment")
         self.redant.hard_terminate(self.server_list, self.client_list,
                                    self.brick_root)
-        if clear_logs:
+        if clear_logs == "Yes":
             self.redant.delete_glusterfs_logs(self.server_list,
                                               self.client_list)
+        elif clear_logs == "No":
+            self.redant.logger.debug("Not clearing the old glusterfs logs")
+        else:
+            self.redant.logger.error("Incorrect argument passed to "
+                                     "'--clear-old-logs'")
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)

--- a/core/environ.py
+++ b/core/environ.py
@@ -123,7 +123,7 @@ class environ:
             self.redant.execute_abstract_op_multinode(cmd,
                                                       arequal_machines)
 
-    def setup_env(self, clear_logs):
+    def setup_env(self, keep_logs):
         """
         Setting up of the environment before the TC execution begins.
         """
@@ -131,7 +131,7 @@ class environ:
         self.spinner.start("Setting up environment")
         self.redant.hard_terminate(self.server_list, self.client_list,
                                    self.brick_root)
-        if not clear_logs:
+        if not keep_logs:
             self.redant.delete_glusterfs_logs(self.server_list,
                                               self.client_list)
         else:

--- a/core/environ.py
+++ b/core/environ.py
@@ -131,14 +131,11 @@ class environ:
         self.spinner.start("Setting up environment")
         self.redant.hard_terminate(self.server_list, self.client_list,
                                    self.brick_root)
-        if clear_logs == "Yes":
+        if not clear_logs:
             self.redant.delete_glusterfs_logs(self.server_list,
                                               self.client_list)
-        elif clear_logs == "No":
-            self.redant.logger.debug("Not clearing the old glusterfs logs")
         else:
-            self.redant.logger.error("Incorrect argument passed to "
-                                     "'--clear-old-logs'")
+            self.redant.logger.debug("Not clearing the old glusterfs logs")
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -53,8 +53,8 @@ def pars_args():
                         dest="show_backtrace", action='store_true')
     parser.add_argument("--clear-old-logs",
                         help="Clear glusterfs logs directory during "
-                        "environment setup",
-                        dest="clear_logs", default=True, type=bool)
+                        "environment setup. Default is Yes",
+                        dest="clear_logs", default="Yes", type=str)
     return parser.parse_args()
 
 

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -54,7 +54,7 @@ def pars_args():
     parser.add_argument("-kold", "--keep-old-logs",
                         help="Don't clear the old glusterfs logs directory "
                         "during environment setup",
-                        dest="clear_logs", action='store_true')
+                        dest="keep_logs", action='store_true')
     return parser.parse_args()
 
 
@@ -128,7 +128,7 @@ def main():
                       args.log_level)
     logger_obj = env_set.get_framework_logger()
     logger_obj.debug("Running env setup.")
-    env_set.setup_env(args.clear_logs)
+    env_set.setup_env(args.keep_logs)
 
     # invoke the test_runner.
     logger_obj.debug("Running the test cases.")

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -51,10 +51,10 @@ def pars_args():
     parser.add_argument("--show-backtrace",
                         help="Show full backtrace on error",
                         dest="show_backtrace", action='store_true')
-    parser.add_argument("-cold", "--clear-old-logs",
-                        help="Clear glusterfs logs directory during "
-                        "environment setup",
-                        dest="clear_logs", default=None, type=str)
+    parser.add_argument("-kold", "--keep-old-logs",
+                        help="Don't clear the old glusterfs logs directory "
+                        "during environment setup",
+                        dest="clear_logs", action='store_true')
     return parser.parse_args()
 
 

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -51,6 +51,10 @@ def pars_args():
     parser.add_argument("--show-backtrace",
                         help="Show full backtrace on error",
                         dest="show_backtrace", action='store_true')
+    parser.add_argument("--clear-old-logs",
+                        help="Clear glusterfs logs directory during "
+                        "environment setup",
+                        dest="clear_logs", default=True, type=bool)
     return parser.parse_args()
 
 
@@ -124,7 +128,7 @@ def main():
                       args.log_level)
     logger_obj = env_set.get_framework_logger()
     logger_obj.debug("Running env setup.")
-    env_set.setup_env()
+    env_set.setup_env(args.clear_logs)
 
     # invoke the test_runner.
     logger_obj.debug("Running the test cases.")

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -51,7 +51,7 @@ def pars_args():
     parser.add_argument("--show-backtrace",
                         help="Show full backtrace on error",
                         dest="show_backtrace", action='store_true')
-    parser.add_argument("--clear-old-logs",
+    parser.add_argument("-cold", "--clear-old-logs",
                         help="Clear glusterfs logs directory during "
                         "environment setup. Default is Yes",
                         dest="clear_logs", default="Yes", type=str)

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -53,8 +53,8 @@ def pars_args():
                         dest="show_backtrace", action='store_true')
     parser.add_argument("-cold", "--clear-old-logs",
                         help="Clear glusterfs logs directory during "
-                        "environment setup. Default is Yes",
-                        dest="clear_logs", default="Yes", type=str)
+                        "environment setup",
+                        dest="clear_logs", default=None, type=str)
     return parser.parse_args()
 
 


### PR DESCRIPTION
### Description:

Added a flag to allow clearing of old glusterfs logs at the time of environment setup. By default, the value is set to True.
Fixes: #980 

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
