### PR TITLE
[Core] Changing default dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ config file with relevant values. The command has to be run from the main redant
 reository. The tests path should be given with respect to the redant directory.
 `python3 ./core/redant_main.py -c ./config/config.yml -t tests/example/`
 For more options, run `python3 ./core/redant_main.py --help`
-7. Log files can be found at /tmp/redant/ [ default path ].
+7. Log files can be found at /var/log/redant/ [ default path ].
 
 The logging is specific to a TC run. So when a user gives a specific base dir
 for logging when invoking `redant_main.py`, that directory will inturn

--- a/common/ops/gluster_ops/dht_ops.py
+++ b/common/ops/gluster_ops/dht_ops.py
@@ -224,7 +224,8 @@ class DHTOps(AbstractOps):
                              len(filename))))
             hash_value = int(computed_hash.value)
         except OSError:
-            cmd = f"python3 /tmp/compute_hash.py {filename}"
+            cmd = ("python3 /usr/share/redant/script/compute_hash.py "
+                   f"{filename}")
             ret = self.execute_abstract_op_node(cmd, host, False)
             if ret['error_code'] != 0:
                 self.logger.error(f"Unable to run the script on node: {host}")

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -206,7 +206,7 @@ class IoOps(AbstractOps):
             }
         """
         ret_val = {'error_code': 0, 'msg': ''}
-        cmd = (f"python3 /tmp/file_dir_ops.py stat {path}")
+        cmd = (f"python3 /usr/share/redant/script/file_dir_ops.py stat {path}")
         ret = self.execute_abstract_op_node(cmd, node, False)
         if ret['error_code'] != 0:
             ret_val['error_code'] = ret['error_code']
@@ -256,8 +256,8 @@ class IoOps(AbstractOps):
         Returns:
             async_object
         """
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files "
-               f"-f {num_files} --fixed-file-size {fix_fil_size} "
+        cmd = (f"python3 /usr/share/redant/script/file_dir_ops.py create_files"
+               f" -f {num_files} --fixed-file-size {fix_fil_size} "
                f"--base-file-name {base_file_name} "
                f"--file-types {file_type} {path}")
         return self.execute_command_async(cmd, node)
@@ -282,8 +282,9 @@ class IoOps(AbstractOps):
         Returns:
             async_object
         """
-        cmd = (f"python3 /tmp/file_dir_ops.py create_deep_dirs_with_files "
-               f"--dirname-start-num {dir_start_no} --dir-depth {dir_depth}"
+        cmd = (f"python3 /usr/share/redant/share/file_dir_ops.py"
+               f" create_deep_dirs_with_files --dirname-start-num"
+               f" {dir_start_no} --dir-depth {dir_depth}"
                f" --dir-length {dir_length} --max-num-of-dirs {max_no_dirs} "
                f"--num-of-files {no_files} {path}")
         return self.execute_command_async(cmd, node)
@@ -570,7 +571,8 @@ class IoOps(AbstractOps):
         for mount in mounts:
             self.logger.info(
                 f"Stat of mount {mount['client']}:{mount['mountpath']}")
-            cmd = f"python3 /tmp/file_dir_ops.py stat -R {mount['mountpath']}"
+            cmd = (f"python3 /usr/share/redant/script/file_dir_ops.py stat -R"
+                   f" {mount['mountpath']}")
             ret = self.execute_abstract_op_node(cmd, mount['client'], False)
             if ret['error_code'] != 0:
                 _rc = False

--- a/core/environ.py
+++ b/core/environ.py
@@ -65,6 +65,9 @@ class environ:
         path
         """
         remove = False
+        for node in machines:
+            self.redant.create_dir('/usr/share/', 'redant/script', node)
+
         if self.redant.path_exists(machines,
                                    [dpath]):
             remove = True
@@ -79,7 +82,8 @@ class environ:
         Check if the I/O script exists in the client
         machines. If not transfer it there.
         """
-        scripts_dpath = ['/tmp/file_dir_ops.py', '/tmp/compute_hash.py']
+        scripts_dpath = ['/usr/share/redant/script/file_dir_ops.py',
+                         '/usr/share/redant/script/compute_hash.py']
         scripts_spath = ['tools/file_dir_ops.py', 'tools/compute_hash.py']
 
         total_nodes = list(set(self.client_list + self.server_list))
@@ -109,7 +113,7 @@ class environ:
         the servers and clients and if not present
         installs it.
         """
-        arequal_dpath = '/tmp/arequal_install.sh'
+        arequal_dpath = '/usr/share/redant/script/arequal_install.sh'
         arequal_spath = f'{os.getcwd()}/tools/arequal_install.sh'
         arequal_machines = self._list_of_machines_without_arequal(
             self.client_list + self.server_list

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -38,7 +38,8 @@ def pars_args():
                         dest="test_dir", default=None, type=str, required=True)
     parser.add_argument("-l", "--log-dir",
                         help="The directory wherein log will be stored.",
-                        dest="log_dir", default="/tmp/redant", type=str)
+                        dest="log_dir", default="/var/log/redant",
+                        type=str)
     parser.add_argument("-ll", "--log-level",
                         help="The log level. Default log level is Info",
                         dest="log_level", default="I", type=str)
@@ -165,9 +166,9 @@ if __name__ == '__main__':
     if failure:
         time_now = time.time()
         try:
-            f = open(f"/tmp/redant/redant-{time_now}", 'w')
+            f = open(f"/var/log/redant/redant-{time_now}", 'w')
             f.write(error_string)
             f.close()
-            print(f"Traceback put into /tmp/redant/redant-{time_now}")
+            print(f"Traceback put into /var/log/redant/redant-{time_now}")
         except Exception as err:
             print(f"Couldn't write main exception {error_string} due to {err}")

--- a/docs/catch_all_exception.md
+++ b/docs/catch_all_exception.md
@@ -4,4 +4,4 @@ Projects grow over time and sometimes in ways in which it wasn't even planned fo
 
 One of the ways this is being handled in redant is with the help of a catch all exception handler in redant_main over the main() call. This handler will catch any exception which has not been thought of. Now comes the question as to where this exception will be stored ? We don't know where redant will be failing, what if it fails even before the log initialization ? This would mean a rudimentary way of logging the exception and the traceback.
 
-The location for this error and traceback is `/tmp/redant/redant-<timestamp>`. Along with putting this exception in file, there's also an indication which is put into stdout for where to find the traceback if there is any.
+The location for this error and traceback is `/var/log/redant/redant-<timestamp>`. Along with putting this exception in file, there's also an indication which is put into stdout for where to find the traceback if there is any.

--- a/tests/functional/afr/test_afr_with_snapshot.py
+++ b/tests/functional/afr/test_afr_with_snapshot.py
@@ -42,12 +42,13 @@ class TestAFRSnapshot(DParentTest):
         - Get arequal after restoring snapshot
         - Compare arequals
         """
+        script_file_path = "/usr/share/redant/file_dir_ops.py"
         self.all_mounts_procs = []
         self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
         # Creating files on client side
         count = 1
         for mount_obj in self.mounts:
-            cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 200 "
+            cmd = (f"python3 {script_file_path} create_files -f 200 "
                    f"--base-file-name file_{count} {mount_obj['mountpath']}")
             proc = redant.execute_command_async(cmd, mount_obj['client'])
             self.all_mounts_procs.append(proc)
@@ -68,7 +69,7 @@ class TestAFRSnapshot(DParentTest):
         # Modify the data
         self.all_mounts_procs = []
         for mount_obj in self.mounts:
-            cmd = ("python3 /tmp/file_dir_ops.py append "
+            cmd = (f"python3 {script_file_path} append "
                    f"{mount_obj['mountpath']}")
             proc = redant.execute_command_async(cmd, mount_obj['client'])
             self.all_mounts_procs.append(proc)

--- a/tests/functional/afr/test_afr_with_snapshot_delete.py
+++ b/tests/functional/afr/test_afr_with_snapshot_delete.py
@@ -44,12 +44,13 @@ class TestAFRSnapshot(DParentTest):
         - Get arequal after restoring snapshot
         - Compare arequals
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         self.all_mounts_procs = []
         self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
         # Creating files on client side
         count = 1
         for mount_obj in self.mounts:
-            cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 50 "
+            cmd = (f"python3 {script_file_path} create_files -f 50 "
                    f"--base-file-name file_{count} {mount_obj['mountpath']}")
             proc = redant.execute_command_async(cmd, mount_obj['client'])
             self.all_mounts_procs.append(proc)
@@ -120,7 +121,7 @@ class TestAFRSnapshot(DParentTest):
         # Creating files on client side
         count = 1
         for mount_obj in self.mounts:
-            cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 50 "
+            cmd = (f"python3 {script_file_path} create_files -f 50 "
                    f"--base-file-name file_{count} {mount_obj['mountpath']}")
             proc = redant.execute_command_async(cmd, mount_obj['client'])
             self.all_mounts_procs.append(proc)
@@ -132,7 +133,7 @@ class TestAFRSnapshot(DParentTest):
 
         # Rename files
         self.all_mounts_procs = []
-        cmd = ("python3 /tmp/file_dir_ops.py mv -s FirstRename"
+        cmd = (f"python3 {script_file_path} mv -s FirstRename"
                f" {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])
         self.all_mounts_procs.append(proc)
@@ -152,7 +153,7 @@ class TestAFRSnapshot(DParentTest):
 
         # Rename files
         self.all_mounts_procs = []
-        cmd = ("python3 /tmp/file_dir_ops.py mv -s SecondRename "
+        cmd = (f"python3 {script_file_path} mv -s SecondRename "
                f" {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])
         self.all_mounts_procs.append(proc)

--- a/tests/functional/afr/test_afr_with_snapshot_rename.py
+++ b/tests/functional/afr/test_afr_with_snapshot_rename.py
@@ -44,12 +44,13 @@ class TestAFRSnapshot(DParentTest):
         - Get arequal after restoring snapshot
         - Compare arequals
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         self.all_mounts_procs = []
         self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
         # Creating files on client side
         count = 1
         for mount_obj in self.mounts:
-            cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 50 "
+            cmd = (f"python3 {script_file_path} create_files -f 50 "
                    f"--base-file-name file_{count} {mount_obj['mountpath']}")
             proc = redant.execute_command_async(cmd, mount_obj['client'])
             self.all_mounts_procs.append(proc)
@@ -61,7 +62,7 @@ class TestAFRSnapshot(DParentTest):
 
         # Rename files
         self.all_mounts_procs = []
-        cmd = ("python3 /tmp/file_dir_ops.py mv -s FirstRename"
+        cmd = (f"python3 {script_file_path} mv -s FirstRename"
                f" {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])
         self.all_mounts_procs.append(proc)
@@ -81,7 +82,7 @@ class TestAFRSnapshot(DParentTest):
 
         # Rename files
         self.all_mounts_procs = []
-        cmd = ("python3 /tmp/file_dir_ops.py mv -s SecondRename "
+        cmd = (f"python3 {script_file_path} mv -s SecondRename "
                f" {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])
         self.all_mounts_procs.append(proc)

--- a/tests/functional/afr/test_arb_to_repl_conversion_with_io.py
+++ b/tests/functional/afr/test_arb_to_repl_conversion_with_io.py
@@ -69,10 +69,11 @@ class TestArbiterToReplicatedConversion(DParentTest):
         - Validate heal completes with no errors and arequal of first dir
           matches against initial checksum
         """
+        script_file_path = "usr/share/redant/script/file_dir_ops.py"
         self.proc_list = []
 
         # Fill IO in first directory
-        cmd = ("python3 /tmp/file_dir_ops.py create_deep_dirs_with_files "
+        cmd = (f"python3 {script_file_path} create_deep_dirs_with_files "
                "--dir-depth 10 --fixed-file-size 1M --num-of-files 100 "
                f"--dirname-start-num 1 {self.mountpoint}")
         redant.execute_abstract_op_node(cmd, self.client_list[0])
@@ -85,7 +86,7 @@ class TestArbiterToReplicatedConversion(DParentTest):
         exp_arequal = redant.collect_mounts_arequal(self.mounts, "user1")
 
         # Start continuous IO from second directory
-        cmd = ("python3 /tmp/file_dir_ops.py create_deep_dirs_with_files "
+        cmd = (f"python3 {script_file_path} create_deep_dirs_with_files "
                "--dir-depth 10 --fixed-file-size 1M --num-of-files 250 "
                f"--dirname-start-num 2 {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])

--- a/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
@@ -31,6 +31,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
+        self.script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         conf_hash = self.vol_type_inf[self.volume_type]
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
@@ -52,8 +53,8 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # Start IO (write/read), must succeed
         all_mounts_procs = []
         self.redant.logger.info("Creating new file on mountpoint...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 10"
-               f" --base-file-name {filename} {self.mounts['mountpath']}")
+        cmd = (f"python3 {self.script_file_path} create_files "
+               f"-f 10 --base-file-name {filename} {self.mounts['mountpath']}")
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
 
@@ -65,7 +66,8 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # Read files on mountpoint
         self.redant.logger.info("Starting reading files on mountpoint")
         all_mounts_procs = []
-        cmd = f"python3 /tmp/file_dir_ops.py read {self.mounts['mountpath']}"
+        cmd = (f"python3 {self.script_file_path} read"
+               f" {self.mounts['mountpath']}")
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
 
@@ -82,7 +84,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # Start IO (write/read), read must succeed, but write should fail
         all_mounts_procs = []
         self.redant.logger.info("Creating new file on mountpoint...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 10"
+        cmd = (f"python3 {self.script_file_path} create_files -f 10"
                f" --base-file-name {filename} {self.mounts['mountpath']}")
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
@@ -97,7 +99,8 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # Read files on mountpoint
         self.redant.logger.info("Starting reading files on mountpoint")
         all_mounts_procs = []
-        cmd = f"python3 /tmp/file_dir_ops.py read {self.mounts['mountpath']}"
+        cmd = (f"python3 {self.script_file_path} read"
+               f" {self.mounts['mountpath']}"
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
 

--- a/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
@@ -100,7 +100,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         self.redant.logger.info("Starting reading files on mountpoint")
         all_mounts_procs = []
         cmd = (f"python3 {self.script_file_path} read"
-               f" {self.mounts['mountpath']}"
+               f" {self.mounts['mountpath']}")
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
 

--- a/tests/functional/afr/test_client_side_quorum_with_auto_option.py
+++ b/tests/functional/afr/test_client_side_quorum_with_auto_option.py
@@ -41,8 +41,8 @@ class TestClientSideQuorumTests(DParentTest):
 
         # write files on all mounts
         redant.logger.info("Starting IO on all mounts...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files "
-               f"-f 10 --base-file-name file {self.mountpoint}")
+        cmd = (f"python3 /usr/share/redant/script/file_dir_ops.py create_files"
+               f" -f 10 --base-file-name file {self.mountpoint}")
         redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # get the subvolumes

--- a/tests/functional/afr/test_client_side_quorum_with_auto_option_overwrite_fixed.py
+++ b/tests/functional/afr/test_client_side_quorum_with_auto_option_overwrite_fixed.py
@@ -39,6 +39,7 @@ class TestClientSideQuorumTests(DParentTest):
         * set cluster.quorum-type to auto
 
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # check the default value of cluster.quorum-type
         option = "cluster.quorum-type"
         ret = redant.get_volume_options(self.vol_name, option,
@@ -73,7 +74,7 @@ class TestClientSideQuorumTests(DParentTest):
 
         # create files
         redant.logger.info("Starting IO on all mounts...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files "
+        cmd = (f"python3 {script_file_path} create_files "
                f"-f 10 --base-file-name file {self.mountpoint}")
         redant.execute_abstract_op_node(cmd, self.client_list[0])
 
@@ -92,7 +93,7 @@ class TestClientSideQuorumTests(DParentTest):
 
         # create files
         redant.logger.info("Starting IO on all mounts...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files "
+        cmd = (f"python3 {script_file_path} create_files "
                f"-f 10 --base-file-name second_file {self.mountpoint}")
         redant.execute_abstract_op_node(cmd, self.client_list[0])
 

--- a/tests/functional/afr/test_client_side_quorum_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_with_cross2.py
@@ -53,6 +53,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         * kill 2-nd brick process from the each and every replica set
         * perform ops
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # set cluster.quorum-type to auto
         options = {"cluster.quorum-type": "auto"}
         redant.set_volume_options(self.vol_name, options, self.server_list[0])
@@ -60,8 +61,8 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # Start IO on mounts
         all_mounts_procs = []
         redant.logger.info("Starting IO on mountpoint...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files "
-               f"-f 10 --base-file-name file {self.mountpoint}")
+        cmd = (f"python3 {script_file_path} create_files -f 10"
+               f" --base-file-name file {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])
         all_mounts_procs.append(proc)
         self.mounts = {
@@ -92,8 +93,8 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # create new file named newfile0.txt
         all_mounts_procs = []
         redant.logger.info("Creating new file on mountpoint...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files "
-               f"-f 1 --base-file-name newfile {self.mountpoint}")
+        cmd = (f"python3 {script_file_path} create_files -f 1 --base-file-name"
+               f" newfile {self.mountpoint}")
         proc = redant.execute_command_async(cmd, self.client_list[0])
         all_mounts_procs.append(proc)
 
@@ -105,8 +106,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # create directory user1
         all_mounts_procs = []
         redant.logger.info("Start creating directory on mountpoint...")
-        cmd = ("python3 /tmp/file_dir_ops.py create_deep_dir "
-               f"{self.mountpoint}")
+        cmd = f"python3 {script_file_path} create_deep_dir {self.mountpoint}"
         proc = redant.execute_command_async(cmd, self.client_list[0])
         all_mounts_procs.append(proc)
 
@@ -146,7 +146,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         # read the file
         redant.logger.info("Starting reading files on mountpoint")
         all_mounts_procs = []
-        cmd = f"python3 /tmp/file_dir_ops.py read {self.mountpoint}"
+        cmd = f"python3 {script_file_path} read {self.mountpoint}"
         proc = redant.execute_command_async(cmd, self.client_list[0])
         all_mounts_procs.append(proc)
 

--- a/tests/functional/afr/test_client_side_quorum_with_fixed_for_cross3.py
+++ b/tests/functional/afr/test_client_side_quorum_with_fixed_for_cross3.py
@@ -29,10 +29,11 @@ class TestClientSideQuorumTestsWithSingleVolumeCross3(DParentTest):
         """
         Perform write and read IO on mountpoint
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # Start IO (write/read), must succeed
         all_mounts_procs = []
         self.redant.logger.info("Creating new file on mountpoint...")
-        cmd = (f"python3 /tmp/file_dir_ops.py create_files -f 10"
+        cmd = (f"python3 {script_file_path} create_files -f 10"
                f" --base-file-name {filename} {self.mounts['mountpath']}")
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
@@ -45,7 +46,7 @@ class TestClientSideQuorumTestsWithSingleVolumeCross3(DParentTest):
         # Read files on mountpoint
         self.redant.logger.info("Starting reading files on mountpoint")
         all_mounts_procs = []
-        cmd = f"python3 /tmp/file_dir_ops.py read {self.mounts['mountpath']}"
+        cmd = f"python3 {script_file_path} read {self.mounts['mountpath']}"
         proc = self.redant.execute_command_async(cmd, self.mounts['client'])
         all_mounts_procs.append(proc)
 

--- a/tests/functional/afr/test_client_side_quorum_with_multiple_volumes.py
+++ b/tests/functional/afr/test_client_side_quorum_with_multiple_volumes.py
@@ -81,8 +81,9 @@ class TestClientSideQuorumTestsMultipleVols(DParentTest):
         # Creating files for all volumes
         for mount_point in self.mounts_list:
             self.all_mounts_procs = []
-            command = ("python3 /tmp/file_dir_ops.py create_files -f 50 "
-                       f"--fixed-file-size 1k {mount_point}")
+            command = (f"python3 /usr/share/redant/script/file_dir_ops.py "
+                       "create_files -f 50 --fixed-file-size 1k"
+                       f" {mount_point}")
             proc = redant.execute_command_async(command, self.client_list[0])
             self.all_mounts_procs.append(proc)
 

--- a/tests/functional/afr/test_metadata_self_heal_client_side_heal.py
+++ b/tests/functional/afr/test_metadata_self_heal_client_side_heal.py
@@ -54,8 +54,8 @@ class TestAFRMetaDataSelfHealClientSideHeal(DParentTest):
                                  self.mountpoint, self.client_list[0])
 
         # Trigger heal from client side
-        cmd = (f"python3 /tmp/file_dir_ops.py read {self.mountpoint}/"
-               f"{self.self_heal_folder}")
+        cmd = (f"python3 /usr/share/redant/script/file_dir_ops.py read"
+               f"{self.mountpoint}/{self.self_heal_folder}")
         self.redant.execute_abstract_op_node(cmd, self.client_list[0])
 
     def validate_io_on_clients(self):

--- a/tests/functional/afr/test_multiple_clients_dd_on_same_file_default.py
+++ b/tests/functional/afr/test_multiple_clients_dd_on_same_file_default.py
@@ -84,8 +84,8 @@ class TestVerifySelfHealTriggersHealCommand(DParentTest):
         # Reading files on client side
         self.all_mounts_procs_read = []
         for mount_obj in self.mounts:
-            command = ("python3 /tmp/file_dir_ops.py read "
-                       f"{mount_obj['mountpath']}")
+            command = (f"python3 /usr/share/redant/script/file_dir_ops.py"
+                       f" read {mount_obj['mountpath']}")
 
             proc = redant.execute_command_async(command, mount_obj['client'])
             self.all_mounts_procs_read.append(proc)

--- a/tests/functional/afr/test_replace_brick_self_heal_io_in_progress.py
+++ b/tests/functional/afr/test_replace_brick_self_heal_io_in_progress.py
@@ -54,8 +54,9 @@ class TestAFRSelfHeal(DParentTest):
         - Calculate arequals of the mount point and all the bricks
         """
         self.io_validation_complete = True
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # Create dirs with files
-        command = ("python3 /tmp/file_dir_ops.py create_deep_dirs_with_files "
+        command = (f"python3 {script_file_path} create_deep_dirs_with_files "
                    f"-d 2 -l 2 -n 2 -f 10 {self.mountpoint}")
         redant.execute_abstract_op_node(command, self.client_list[0])
 

--- a/tests/functional/afr/test_volume_set_options.py
+++ b/tests/functional/afr/test_volume_set_options.py
@@ -154,7 +154,7 @@ class TestVolumeSetDataSelfHealTests(DParentTest):
         # Trigger heal from mount point
         redant.logger.info('Starting heal from mount point...')
         for mount_obj in self.mounts:
-            cmd = ("python3 /tmp/file_dir_ops.py stat -R "
+            cmd = ("python3 /usr/share/redant/script/file_dir_ops.py stat -R "
                    f"{mount_obj['mountpath']}/test_data_self_heal")
             ret = redant.execute_abstract_op_node(cmd, mount_obj['client'])
             if ret['error_code'] != 0:

--- a/tests/functional/arbiter/test_data_self_heal_algorithm_diff_default.py
+++ b/tests/functional/arbiter/test_data_self_heal_algorithm_diff_default.py
@@ -39,13 +39,14 @@ class TestSelfHeal(DParentTest):
         - calculate arequal and compare with arequal before bringing bricks
         offline and after bringing bricks online
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # Setting options
         options = {"data-self-heal-algorithm": "diff"}
         redant.set_volume_options(self.vol_name, options, self.server_list[0])
 
         # Creating files on client side
         mount_dict = []
-        cmd = ("python3 /tmp/file_dir_ops.py create_files -f 100 "
+        cmd = (f"python3 {script_file_path} create_files -f 100 "
                f"{self.mountpoint}")
 
         proc = redant.execute_command_async(cmd, self.client_list[0])
@@ -72,7 +73,7 @@ class TestSelfHeal(DParentTest):
             raise Exception(f"Bricks {offline_brick_list} are not offline")
 
         # Modify the data
-        cmd = ("python3 /tmp/file_dir_ops.py create_files -f 100 "
+        cmd = (f"python3 {script_file_path} create_files -f 100 "
                f" --fixed-file-size 1M {self.mountpoint}")
 
         proc = redant.execute_command_async(cmd, self.client_list[0])

--- a/tests/functional/arbiter/test_data_self_heal_algorithm_diff_heal_command.py
+++ b/tests/functional/arbiter/test_data_self_heal_algorithm_diff_heal_command.py
@@ -51,6 +51,7 @@ class TestSelfHeal(DParentTest):
         - calculate arequal and compare with arequal before bringing bricks
           offline and after bringing bricks online
         """
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # Setting options
         options = {"metadata-self-heal": "off",
                    "entry-self-heal": "off",
@@ -61,7 +62,7 @@ class TestSelfHeal(DParentTest):
 
         # Creating files on client side
         mount_dict = []
-        cmd = ("python3 /tmp/file_dir_ops.py create_files -f 100 "
+        cmd = ("python3 {script_file_path} create_files -f 100 "
                f"{self.mountpoint}")
 
         proc = redant.execute_command_async(cmd, self.client_list[0])
@@ -92,7 +93,7 @@ class TestSelfHeal(DParentTest):
             raise Exception(f"Bricks {offline_brick_list} are not offline")
 
         # Modify the data
-        cmd = ("python3 /tmp/file_dir_ops.py create_files -f 100 "
+        cmd = ("python3 {script_file_path} create_files -f 100 "
                f" --fixed-file-size 1M {self.mountpoint}")
 
         proc = redant.execute_command_async(cmd, self.client_list[0])

--- a/tests/functional/arbiter/test_entry_self_heal_heal_command.py
+++ b/tests/functional/arbiter/test_entry_self_heal_heal_command.py
@@ -69,15 +69,16 @@ class TestSelfHeal(DParentTest):
         if not ret:
             raise Exception("IO validation failed")
 
+        script_file_path = "/usr/share/redant/script/file_dir_ops.py"
         # Command list to do different operations with data -
         # create, rename, copy and delete
         cmds = (
-            ("python3 /tmp/file_dir_ops.py create_files -f 20 "
+            ("python3 {script_file_path} create_files -f 20 "
              f"{self.mountpoint}/files"),
-            f"python3 /tmp/file_dir_ops.py mv {self.mountpoint}/files",
-            ("python3 /tmp/file_dir_ops.py copy --dest-dir "
+            f"python3 {script_file_path} mv {self.mountpoint}/files",
+            ("python3 {script_file_path} copy --dest-dir "
              f"{self.mountpoint}/new_dir {self.mountpoint}/files"),
-            f"python3 /tmp/file_dir_ops.py delete {self.mountpoint}",
+            f"python3 {script_file_path} delete {self.mountpoint}",
         )
         for cmd in cmds:
             # Get arequal before getting bricks offline

--- a/tests/functional/arbiter/test_handling_data_split_brain_of_files_heal_command.py
+++ b/tests/functional/arbiter/test_handling_data_split_brain_of_files_heal_command.py
@@ -194,7 +194,7 @@ class TestCase(DParentTest):
 
         # Start heal from mount point
         for mount_obj in self.mounts:
-            command = ("python3 /tmp/file_dir_ops.py "
+            command = ("python3 /usr/share/redant/script/file_dir_ops.py "
                        f"read {mount_obj['mountpath']}")
             redant.execute_abstract_op_node(command,
                                             mount_obj['client'])

--- a/tools/log_server/log_access.ini
+++ b/tools/log_server/log_access.ini
@@ -1,3 +1,3 @@
 [serverdata]
-path: /tmp/redant
+path: /var/log/redant
 port: 5000

--- a/tools/log_server/log_access.py
+++ b/tools/log_server/log_access.py
@@ -12,15 +12,15 @@ def main():
             config.read('log_access.ini')
     except IOError:
         print("log_access.ini doesn't exist. Hence taking a default dict."
-              " with path : /tmp/redant and port : 5000")
-        config = {"serverdata": {"path": "/tmp/redant", "port": 5000}}
+              " with path : /var/log/redant and port : 5000")
+        config = {"serverdata": {"path": "/var/log/redant", "port": 5000}}
 
     # Path extraction and validation.
     try:
         ppath = config['serverdata']['path']
     except Exception as KeyError:
-        print("Key error in path. Defaulting to /tmp/redant as log path.")
-        ppath = "/tmp/redant"
+        print("Key error in path. Defaulting to /var/log/redant as log path.")
+        ppath = "/var/log/redant"
 
     # Port extraction and validation.
     try:


### PR DESCRIPTION
Changed the default dir for the following,
1. The logs will now be present at `/var/log/redant`
by default.
2. The io scripts will be placed at
`/usr/share/redant/script`.

Fixes: #988 

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
