### PR TITLE
[Test] Bringing custom terminate under t-e block

### DIFF
--- a/tests/functional/arbiter/test_metadata_self_heal_on_open_fd.py
+++ b/tests/functional/arbiter/test_metadata_self_heal_on_open_fd.py
@@ -31,15 +31,15 @@ from tests.d_parent_test import DParentTest
 class TestCase(DParentTest):
 
     def terminate(self):
-        for node in self.nodes:
-            try:
+        try:
+            for node in self.nodes:
                 if not self.redant.del_user(node,
                                             self.user):
                     raise Exception("Failed to delete user")
-            except Exception as error:
-                tb = traceback.format_exc
-                self.logger.error(error)
-                self.logger.error(tb)
+        except Exception as error:
+            tb = traceback.format_exc
+            self.logger.error(error)
+            self.logger.error(tb)
         super().terminate()
 
     def _verify_stat_info(self, nodes_to_check: list, test_file: str):
@@ -84,9 +84,9 @@ class TestCase(DParentTest):
             should be same.
         """
         self.user = "qa"
-        self.nodes = []
         self.nodes = copy.deepcopy(self.server_list)
-        self.nodes.append(self.client_list[0])
+        client = self.client_list[0]
+        self.nodes.extend(cn for cn in [client] if cn not in self.nodes)
         self.mounts = [{'client': self.client_list[0],
                         'mountpath': self.mountpoint}]
 
@@ -100,8 +100,6 @@ class TestCase(DParentTest):
                                             self.server_list[0])
         if bricks_list is None:
             raise Exception("Brick list is None")
-
-        client = self.client_list[0]
 
         # Create test executable file on mount point
         m_point = self.mountpoint


### PR DESCRIPTION
Following changes have been done in this patch,
1. Bringing the custom terminate logic completely
under the try-except block as the check flag/variable
might not even be defined before its access.
2. Modified how the self.nodes is formed to
restrict the inclusion of a node more than once in it.
This situation can arise if we were to use the same
node as both server and client.

Note: The test case is failing due to mismatch
in username expected. But this patch is not
a fix for that.

Fixes: #1000

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
