### PR TITLE
[Common] Fixing script invocation path

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -282,7 +282,7 @@ class IoOps(AbstractOps):
         Returns:
             async_object
         """
-        cmd = (f"python3 /usr/share/redant/share/file_dir_ops.py"
+        cmd = (f"python3 /usr/share/redant/script/file_dir_ops.py"
                f" create_deep_dirs_with_files --dirname-start-num"
                f" {dir_start_no} --dir-depth {dir_depth}"
                f" --dir-length {dir_length} --max-num-of-dirs {max_no_dirs} "


### PR DESCRIPTION
This patch fixes the path which was used to
invoke the file_dir_ops.py script.

Updates: #1002

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
