### PR TITLE
[Common]Fix form_brick_cmd function

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -422,6 +422,8 @@ class BrickOps(AbstractOps):
             # unused bricks dict as well
             unused_servers.remove(server_val)
             unused_bricks[server_val].remove(brick)
+            if not unused_bricks[server_val]:
+                unused_bricks.pop(server_val)
             iteration += 1
 
         # If we have unused bricks in some node, use them
@@ -469,7 +471,7 @@ class BrickOps(AbstractOps):
         # brick_root
         index = 0
         if brick_cmd:
-            index = self._get_index(nodes, brick_cmd)
+            index = self._get_index(server_list, brick_cmd)
         elif last_node == server_list[index]:
             index += 1
 


### PR DESCRIPTION
**Description:**
The key in unused_bricks was not removed if the value for that key was 'NONE`. Added a check for that, and also updated the list name to use for servers at the later part of the function.

Fixes: #1002 
Signed-off-by: nik-redhat <nladha@redhat.com>
