### PR TITLE
Migrated TC test_snap_info_glusterd_restart

### DIFF
--- a/tests/functional/snapshot/test_snap_info_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_info_glusterd_restart.py
@@ -41,14 +41,14 @@ class SnapshotInfo(GlusterBaseClass):
 
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         cls.snap1 = "snap1"
         cls.snap2 = "snap2"
 
     def setUp(self):
 
         # SettingUp volume and Mounting the volume
-        GlusterBaseClass.setUpClass.im_func(self)
+        self.get_super_method(self, 'setUp')()
         g.log.info("Starting to SetUp Volume")
         ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
         if not ret:

--- a/tests/functional/snapshot/test_snap_info_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_info_glusterd_restart.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,123 +14,128 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Description:
-
-Test Cases in this module tests the
-snapshot information after glusterd
-is restarted.
-
-"""
 from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.gluster_base_class import runs_on
-from glustolibs.gluster.gluster_init import (restart_glusterd,
-                                             is_glusterd_running)
-from glustolibs.gluster.snap_ops import (snap_create,
-                                         get_snap_info,
-                                         get_snap_info_by_volname,
-                                         get_snap_info_by_snapname)
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.gluster_init import (
+    wait_for_glusterd_to_start,
+    restart_glusterd)
+from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
+from glustolibs.gluster.snap_ops import (
+    snap_create,
+    get_snap_info,
+    get_snap_info_by_volname,
+    get_snap_info_by_snapname)
 
 
 @runs_on([['replicated', 'distributed-replicated', 'dispersed',
            'distributed', 'distributed-dispersed'],
-          ['glusterfs', 'nfs', 'cifs']])
-class SnapshotInfo(GlusterBaseClass):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-        cls.snap1 = "snap1"
-        cls.snap2 = "snap2"
+          ['glusterfs']])
+class TestSnapshotInfoGlusterdRestart(GlusterBaseClass):
+    """
+    Test Cases in this module tests the snapshot information
+    after glusterd is restarted.
+    """
 
     def setUp(self):
+        self.get_super_method(self, 'setUp')()
 
         # SettingUp volume and Mounting the volume
-        self.get_super_method(self, 'setUp')()
-        g.log.info("Starting to SetUp Volume")
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        ret = self.setup_volume()
         if not ret:
             raise ExecutionError("Failed to setup volume %s" % self.volname)
         g.log.info("Volume %s has been setup successfully", self.volname)
+        self.snapshots = [('snap-test-snap-info-gd-restart-%s-%s'
+                           % (self.volname, i))for i in range(0, 2)]
 
     def snapshot_info(self):
-        # Check snapshot info using snap name
-        g.log.info("Checking snapshot info using snap name")
-        snap_info_chk = get_snap_info_by_snapname(self.mnode,
-                                                  self.snap1)
-        self.assertIsNotNone(snap_info_chk, "Failed to get snap info")
-        self.assertEqual(snap_info_chk['name'], "%s" % self.snap1,
-                         "Failed to show snapshot info for %s"
-                         % self.snap1)
-        g.log.info("Successfully checked snapshot info for %s", self.snap1)
+        """
+        This section checks the snapshot information:
+        * Using snapname
+        * Using volname
+        * Without using snapname or volname
+        """
+        # Check snapshot info using snapname
+        for snap in self.snapshots:
+            snap_info_chk = get_snap_info_by_snapname(self.mnode, snap)
+            self.assertIsNotNone(snap_info_chk, "Failed to get snap info")
+            self.assertEqual(snap_info_chk['name'], "%s" % snap,
+                             "Failed to show snapshot info for %s" % snap)
+            g.log.info("Successfully validated snapshot info for %s", snap)
 
         # Check snapshot info using volname
-        g.log.info("Checking snapshot info using volname")
         snap_vol_info = get_snap_info_by_volname(self.mnode, self.volname)
         self.assertIsNotNone(snap_vol_info, "Failed to get snap info")
-        self.assertEqual(snap_vol_info['originVolume']['name'], "%s"
-                         % self.volname,
-                         "Failed to show snapshot info for %s"
-                         % self.volname)
-        g.log.info("Successfully checked snapshot info for %s",
-                   self.volname)
+        self.assertEqual(snap_vol_info['originVolume']['name'],
+                         "%s" % self.volname,
+                         "Failed to show snapshot info for %s" % self.volname)
+        g.log.info("Successfully validated snapshot info for %s", self.volname)
 
-        # Validate snapshot information
-        g.log.info("Validating snapshot information")
+        # Validate snapshot information without using snapname or volname
         info_snaps = get_snap_info(self.mnode)
-        self.assertIsNotNone(snap_vol_info, "Failed to get snap info")
-        for snap in range(0, 2):
-            self.assertEqual(info_snaps[snap]['name'], "snap%s" % snap,
-                             "Failed to validate"
-                             "snap information")
-        g.log.info("Successfully Validated snap Information")
+        self.assertIsNotNone(info_snaps, "Failed to get snap info")
+        counter = 0
+        for snap in self.snapshots:
+            self.assertEqual(info_snaps[counter]['name'], snap,
+                             "Failed to validate snap information")
+            counter += 1
+        g.log.info("Successfully validated snapshot information")
 
-    def test_snap_info(self):
+    def test_snap_info_glusterd_restart(self):
         """
-        1. Create volumes
-        2. create multiple snapshots
-        3. Check snapshot info for snapshots created
-           using snap name, using volume name and
-           without using snap name and volume name
-        4. restart glusterd
-        5. follow step 3
+        Verify snapshot info before and after glusterd restart
+
+        * Create multiple snapshots
+        * Check snapshot info
+          - Without using snapname or volname
+          - Using snapname
+          - Using volname
+        * Restart glusterd on all servers
+        * Repeat the snapshot info step for all the three scenarios
+          mentioned above
         """
 
         # pylint: disable=too-many-statements
-        # Creating snapshot with description
-        g.log.info("Starting to Create snapshot")
-        for count in range(0, 2):
-            self.snap = "snap%s" % count
-            ret, _, _ = snap_create(self.mnode, self.volname,
-                                    self.snap,
+        # Create snapshots with description
+        for snap in self.snapshots:
+            ret, _, _ = snap_create(self.mnode, self.volname, snap,
                                     description='$p3C!@l C#@R@cT#R$')
             self.assertEqual(ret, 0, ("Failed to create snapshot for volume %s"
                                       % self.volname))
-        g.log.info("Snapshot %s created successfully"
-                   " for volume %s", self.snap, self.volname)
+            g.log.info("Snapshot %s created successfully for volume %s",
+                       snap, self.volname)
+
+        # Perform the snapshot info tests before glusterd restart
         self.snapshot_info()
 
-        # Restart Glusterd on all node
-        g.log.info("Restarting Glusterd on all node")
-        ret = restart_glusterd(self.servers)
-        self.assertTrue(ret, "Failed to stop glusterd")
-        g.log.info("Successfully stopped glusterd on all node")
+        # Restart Glusterd on all servers
+        for server in self.servers:
+            ret = restart_glusterd(server)
+            self.assertTrue(ret, ("Failed to restart glusterd on node %s"
+                                  % server))
+            g.log.info("Successfully restarted glusterd on node %s", server)
 
-        # Check Glusterd status
-        g.log.info("Check glusterd running or not")
-        ret = is_glusterd_running(self.servers)
-        self.assertEqual(ret, 0, "glusterd running on node ")
-        g.log.info("glusterd is not running")
+        # Wait for glusterd to be online and validate glusterd running on all
+        # server nodes
+        self.assertTrue(
+            wait_for_glusterd_to_start(self.servers),
+            "Unexpected: glusterd not up on one or more of the nodes")
+        g.log.info("Glusterd is up and running on all nodes")
 
+        # Check if peers are connected
+        self.assertTrue(
+            wait_for_peers_to_connect(self.mnode, self.servers),
+            "Unexpected: Peers are not in connected state")
+        g.log.info("Successful: All peers are in connected state")
+
+        # perform the snapshot info tests after glusterd restart
         self.snapshot_info()
 
     def tearDown(self):
+        self.get_super_method(self, 'tearDown')()
 
-        # Unmount and cleanup original volume
-        g.log.info("Starting to Unmount Volume and Cleanup Volume")
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        # Unmount and cleanup volume
+        ret = self.cleanup_volume()
         if not ret:
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
+            raise ExecutionError("Failed to cleanup Volume")
+        g.log.info("Successful in Cleanup volume")

--- a/tests/functional/snapshot/test_snap_info_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_info_glusterd_restart.py
@@ -1,54 +1,31 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.gluster_init import (
-    wait_for_glusterd_to_start,
-    restart_glusterd)
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
-from glustolibs.gluster.snap_ops import (
-    snap_create,
-    get_snap_info,
-    get_snap_info_by_volname,
-    get_snap_info_by_snapname)
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to test the snapshot information after glusterd is restarted.
+"""
+
+# disruptive;rep,dist,dist-rep,disp,dist-disp
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed', 'distributed-dispersed'],
-          ['glusterfs']])
-class TestSnapshotInfoGlusterdRestart(GlusterBaseClass):
-    """
-    Test Cases in this module tests the snapshot information
-    after glusterd is restarted.
-    """
+class TestSnapshotInfoGlusterdRestart(DParentTest):
 
-    def setUp(self):
-        self.get_super_method(self, 'setUp')()
-
-        # SettingUp volume and Mounting the volume
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup volume %s" % self.volname)
-        g.log.info("Volume %s has been setup successfully", self.volname)
-        self.snapshots = [('snap-test-snap-info-gd-restart-%s-%s'
-                           % (self.volname, i))for i in range(0, 2)]
-
-    def snapshot_info(self):
+    def _snapshot_info(self):
         """
         This section checks the snapshot information:
         * Using snapname
@@ -57,34 +34,33 @@ class TestSnapshotInfoGlusterdRestart(GlusterBaseClass):
         """
         # Check snapshot info using snapname
         for snap in self.snapshots:
-            snap_info_chk = get_snap_info_by_snapname(self.mnode, snap)
-            self.assertIsNotNone(snap_info_chk, "Failed to get snap info")
-            self.assertEqual(snap_info_chk['name'], "%s" % snap,
-                             "Failed to show snapshot info for %s" % snap)
-            g.log.info("Successfully validated snapshot info for %s", snap)
+            ret = self.redant.get_snap_info_by_snapname(snap,
+                                                        self.server_list[0])
+            if not ret:
+                raise Exception("Failed to get snap info")
+            if ret['name'] != snap:
+                raise Exception(f"Failed to show snapshot info for {snap}")
 
         # Check snapshot info using volname
-        snap_vol_info = get_snap_info_by_volname(self.mnode, self.volname)
-        self.assertIsNotNone(snap_vol_info, "Failed to get snap info")
-        self.assertEqual(snap_vol_info['originVolume']['name'],
-                         "%s" % self.volname,
-                         "Failed to show snapshot info for %s" % self.volname)
-        g.log.info("Successfully validated snapshot info for %s", self.volname)
+        ret = self.redant.get_snap_info_by_volname(self.vol_name,
+                                                   self.server_list[0])
+        if not ret:
+            raise Exception("Failed to get snap info")
+        if ret['originVolume']['name'] != self.vol_name:
+            raise Exception("Failed to show snapshot info for "
+                            f"{self.vol_name}")
 
         # Validate snapshot information without using snapname or volname
-        info_snaps = get_snap_info(self.mnode)
-        self.assertIsNotNone(info_snaps, "Failed to get snap info")
-        counter = 0
-        for snap in self.snapshots:
-            self.assertEqual(info_snaps[counter]['name'], snap,
-                             "Failed to validate snap information")
-            counter += 1
-        g.log.info("Successfully validated snapshot information")
+        ret = self.redant.get_snap_info(self.server_list[0])
+        if not ret:
+            raise Exception("Failed to get snap info")
 
-    def test_snap_info_glusterd_restart(self):
+        for i, snap in enumerate(self.snapshots):
+            if ret[i]['name'] != snap:
+                raise Exception("Failed to validate snap information")
+
+    def run_test(self, redant):
         """
-        Verify snapshot info before and after glusterd restart
-
         * Create multiple snapshots
         * Check snapshot info
           - Without using snapname or volname
@@ -94,48 +70,30 @@ class TestSnapshotInfoGlusterdRestart(GlusterBaseClass):
         * Repeat the snapshot info step for all the three scenarios
           mentioned above
         """
+        self.snapshots = [(f"snap-test-snap-info-gd-restart-{i}")
+                          for i in range(0, 2)]
 
-        # pylint: disable=too-many-statements
         # Create snapshots with description
         for snap in self.snapshots:
-            ret, _, _ = snap_create(self.mnode, self.volname, snap,
-                                    description='$p3C!@l C#@R@cT#R$')
-            self.assertEqual(ret, 0, ("Failed to create snapshot for volume %s"
-                                      % self.volname))
-            g.log.info("Snapshot %s created successfully for volume %s",
-                       snap, self.volname)
+            redant.snap_create(self.vol_name, f"{snap}",
+                               self.server_list[0],
+                               description="$p3C!@l C#@R@cT#R$")
 
         # Perform the snapshot info tests before glusterd restart
-        self.snapshot_info()
+        self._snapshot_info()
 
         # Restart Glusterd on all servers
-        for server in self.servers:
-            ret = restart_glusterd(server)
-            self.assertTrue(ret, ("Failed to restart glusterd on node %s"
-                                  % server))
-            g.log.info("Successfully restarted glusterd on node %s", server)
+        redant.restart_glusterd(self.server_list)
 
         # Wait for glusterd to be online and validate glusterd running on all
         # server nodes
-        self.assertTrue(
-            wait_for_glusterd_to_start(self.servers),
-            "Unexpected: glusterd not up on one or more of the nodes")
-        g.log.info("Glusterd is up and running on all nodes")
+        if not redant.wait_for_glusterd_to_start(self.server_list):
+            raise Exception(f"Glusterd is not running on {self.server_list}")
 
         # Check if peers are connected
-        self.assertTrue(
-            wait_for_peers_to_connect(self.mnode, self.servers),
-            "Unexpected: Peers are not in connected state")
-        g.log.info("Successful: All peers are in connected state")
+        if not redant.wait_for_peers_to_connect(self.server_list,
+                                                self.server_list[0]):
+            raise Exception("Peers are not yet in connected state")
 
         # perform the snapshot info tests after glusterd restart
-        self.snapshot_info()
-
-    def tearDown(self):
-        self.get_super_method(self, 'tearDown')()
-
-        # Unmount and cleanup volume
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to cleanup Volume")
-        g.log.info("Successful in Cleanup volume")
+        self._snapshot_info()

--- a/tests/functional/snapshot/test_snap_info_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_info_glusterd_restart.py
@@ -1,0 +1,136 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+
+Test Cases in this module tests the
+snapshot information after glusterd
+is restarted.
+
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.gluster_base_class import runs_on
+from glustolibs.gluster.gluster_init import (restart_glusterd,
+                                             is_glusterd_running)
+from glustolibs.gluster.snap_ops import (snap_create,
+                                         get_snap_info,
+                                         get_snap_info_by_volname,
+                                         get_snap_info_by_snapname)
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed', 'distributed-dispersed'],
+          ['glusterfs', 'nfs', 'cifs']])
+class SnapshotInfo(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.snap1 = "snap1"
+        cls.snap2 = "snap2"
+
+    def setUp(self):
+
+        # SettingUp volume and Mounting the volume
+        GlusterBaseClass.setUpClass.im_func(self)
+        g.log.info("Starting to SetUp Volume")
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume %s" % self.volname)
+        g.log.info("Volume %s has been setup successfully", self.volname)
+
+    def snapshot_info(self):
+        # Check snapshot info using snap name
+        g.log.info("Checking snapshot info using snap name")
+        snap_info_chk = get_snap_info_by_snapname(self.mnode,
+                                                  self.snap1)
+        self.assertIsNotNone(snap_info_chk, "Failed to get snap info")
+        self.assertEqual(snap_info_chk['name'], "%s" % self.snap1,
+                         "Failed to show snapshot info for %s"
+                         % self.snap1)
+        g.log.info("Successfully checked snapshot info for %s", self.snap1)
+
+        # Check snapshot info using volname
+        g.log.info("Checking snapshot info using volname")
+        snap_vol_info = get_snap_info_by_volname(self.mnode, self.volname)
+        self.assertIsNotNone(snap_vol_info, "Failed to get snap info")
+        self.assertEqual(snap_vol_info['originVolume']['name'], "%s"
+                         % self.volname,
+                         "Failed to show snapshot info for %s"
+                         % self.volname)
+        g.log.info("Successfully checked snapshot info for %s",
+                   self.volname)
+
+        # Validate snapshot information
+        g.log.info("Validating snapshot information")
+        info_snaps = get_snap_info(self.mnode)
+        self.assertIsNotNone(snap_vol_info, "Failed to get snap info")
+        for snap in range(0, 2):
+            self.assertEqual(info_snaps[snap]['name'], "snap%s" % snap,
+                             "Failed to validate"
+                             "snap information")
+        g.log.info("Successfully Validated snap Information")
+
+    def test_snap_info(self):
+        """
+        1. Create volumes
+        2. create multiple snapshots
+        3. Check snapshot info for snapshots created
+           using snap name, using volume name and
+           without using snap name and volume name
+        4. restart glusterd
+        5. follow step 3
+        """
+
+        # pylint: disable=too-many-statements
+        # Creating snapshot with description
+        g.log.info("Starting to Create snapshot")
+        for count in range(0, 2):
+            self.snap = "snap%s" % count
+            ret, _, _ = snap_create(self.mnode, self.volname,
+                                    self.snap,
+                                    description='$p3C!@l C#@R@cT#R$')
+            self.assertEqual(ret, 0, ("Failed to create snapshot for volume %s"
+                                      % self.volname))
+        g.log.info("Snapshot %s created successfully"
+                   " for volume %s", self.snap, self.volname)
+        self.snapshot_info()
+
+        # Restart Glusterd on all node
+        g.log.info("Restarting Glusterd on all node")
+        ret = restart_glusterd(self.servers)
+        self.assertTrue(ret, "Failed to stop glusterd")
+        g.log.info("Successfully stopped glusterd on all node")
+
+        # Check Glusterd status
+        g.log.info("Check glusterd running or not")
+        ret = is_glusterd_running(self.servers)
+        self.assertEqual(ret, 0, "glusterd running on node ")
+        g.log.info("glusterd is not running")
+
+        self.snapshot_info()
+
+    def tearDown(self):
+
+        # Unmount and cleanup original volume
+        g.log.info("Starting to Unmount Volume and Cleanup Volume")
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")

--- a/tests/functional/snapshot/test_snap_info_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_info_glusterd_restart.py
@@ -38,17 +38,12 @@ class TestSnapshotInfoGlusterdRestart(DParentTest):
                                                         self.server_list[0])
             if not ret:
                 raise Exception("Failed to get snap info")
-            if ret['name'] != snap:
-                raise Exception(f"Failed to show snapshot info for {snap}")
 
         # Check snapshot info using volname
         ret = self.redant.get_snap_info_by_volname(self.vol_name,
                                                    self.server_list[0])
         if not ret:
             raise Exception("Failed to get snap info")
-        if ret['originVolume']['name'] != self.vol_name:
-            raise Exception("Failed to show snapshot info for "
-                            f"{self.vol_name}")
 
         # Validate snapshot information without using snapname or volname
         ret = self.redant.get_snap_info(self.server_list[0])
@@ -56,7 +51,7 @@ class TestSnapshotInfoGlusterdRestart(DParentTest):
             raise Exception("Failed to get snap info")
 
         for i, snap in enumerate(self.snapshots):
-            if ret[i]['name'] != snap:
+            if snap not in ret.keys():
                 raise Exception("Failed to validate snap information")
 
     def run_test(self, redant):


### PR DESCRIPTION
Migrated TC [test_snap_info_glusterd_restart](https://github.com/gluster/glusto-tests/blob/master/tests/functional/snapshot/test_snap_info_glusterd_restart.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>