### PR TITLE
Migrated TC test_snap_status_glusterd_restart

### DIFF
--- a/common/ops/gluster_ops/snapshot_ops.py
+++ b/common/ops/gluster_ops/snapshot_ops.py
@@ -430,13 +430,13 @@ class SnapshotOps(AbstractOps):
             Dictionary of the snap status for the said volume or Nonetype
             object.
         """
-        cmd = f"gluster snapshot status volume {volname} --xml --mode=script"
+        cmd = f"gluster snapshot status volume {volname} --mode=script"
         ret = self.execute_abstract_op_node(cmd, node, excep)
-        return ret
-        # ret = ret['msg']['snapStatus']['snapshots']['snapshot']
+        if not excep:
+            return ret
 
-        # if not excep:
-        #    return ret
+        snap_stats = "".join(ret['msg']).strip('\n')
+        return snap_stats
 
     def snap_info(self, node: str, snapname: str = None, volname: str = None,
                   excep: bool = True) -> dict:

--- a/common/ops/gluster_ops/snapshot_ops.py
+++ b/common/ops/gluster_ops/snapshot_ops.py
@@ -412,6 +412,32 @@ class SnapshotOps(AbstractOps):
             return snap_status_dict[snapname]
         return None
 
+    def get_snap_status_by_volname(self, volname: str, node: str,
+                                   excep: bool = True) -> dict:
+        """
+        Method to get a snap status using the volume.
+
+        Args:
+            volname (str): Name of the volume
+            node (str): node wherein the command is to be executed.
+
+        Optional:
+            excep (bool): Flag to control exception handling by the
+            abstract ops. If True, the exception is handled, or else
+            it isn't.
+
+        Returns:
+            Dictionary of the snap status for the said volume or Nonetype
+            object.
+        """
+        cmd = f"gluster snapshot status volume {volname} --xml --mode=script"
+        ret = self.execute_abstract_op_node(cmd, node, excep)
+        return ret
+        # ret = ret['msg']['snapStatus']['snapshots']['snapshot']
+
+        # if not excep:
+        #    return ret
+
     def snap_info(self, node: str, snapname: str = None, volname: str = None,
                   excep: bool = True) -> dict:
         """

--- a/tests/functional/snapshot/test_snap_status_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_status_glusterd_restart.py
@@ -1,70 +1,32 @@
-#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-Description:
+ Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
 
-Test Cases in this module tests the
-snapshot Status when glusterd is restarted.
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    Test Cases in this module tests the snapshot Status when glusterd is
+    restarted.
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.gluster_base_class import runs_on
-from glustolibs.gluster.gluster_init import (restart_glusterd,
-                                             is_glusterd_running)
-from glustolibs.gluster.snap_ops import (snap_create,
-                                         get_snap_status,
-                                         get_snap_status_by_snapname,
-                                         snap_status_by_volname)
+
+# disruptive;rep,dist,dist-rep,disp,dist-disp
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed', 'distributed-dispersed'],
-          ['glusterfs']])
-class TestSnapshotGlusterdRestart(GlusterBaseClass):
+class TestSnapshotGlusterdRestart(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-        cls.snapshots = [('snap-test-snap-status-gd-restart-%s-%s'
-                          % (cls.volname, i))for i in range(0, 2)]
-
-    def setUp(self):
-
-        # SettingUp volume and Mounting the volume
-        self.get_super_method(self, 'setUp')()
-
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup volume %s" % self.volname)
-        g.log.info("Volume %s has been setup successfully", self.volname)
-
-    def tearDown(self):
-
-        # Unmount and cleanup original volume
-
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-    def test_snap_status_glusterd_restart(self):
-        # pylint: disable=too-many-statements, too-many-branches
+    def run_test(self, redant):
         """
         Test Case:
         1. Create volume
@@ -74,89 +36,59 @@ class TestSnapshotGlusterdRestart(GlusterBaseClass):
         4. Restart glusterd on all nodes
         5. Follow step3 again and validate snapshot
         """
+        self.snapshots = [(f'snap-status-gd-restart-{i}') for i in range(2)]
 
         # Creating snapshot with description
         for snap in self.snapshots:
-            ret, _, _ = snap_create(self.mnode, self.volname, snap,
-                                    description='$p3C!@l C#@R@cT#R$')
-            self.assertEqual(ret, 0, ("Failed to create snapshot for volume %s"
-                                      % self.volname))
-            g.log.info("Snapshot %s created successfully"
-                       " for volume %s", snap, self.volname)
+            redant.snap_create(self.vol_name, snap, self.server_list[0],
+                               description='$p3C!@l C#@R@cT#R$')
 
         # Validate snapshot status information
         # Check snapshot status
-        snap_stat = get_snap_status(self.mnode)
-        self.assertIsNotNone(snap_stat, "failed to get snap status")
-        snap_count = 0
+        snap_stat = redant.get_snap_status(self.server_list[0])
         for snap in self.snapshots:
-            self.assertEqual(snap_stat[snap_count]['name'],
-                             snap, "Failed to show snapshot status")
-            snap_count += 1
-        g.log.info("Successfully checked snapshot status")
+            if snap not in snap_stat:
+                raise Exception("Failed to show snapshot status")
 
         # Check snapshot status using snap name
-        snap_status = get_snap_status_by_snapname(self.mnode,
-                                                  self.snapshots[0])
-        self.assertIsNotNone(snap_status, "failed to get snap status")
-        self.assertEqual(snap_status['name'], "%s" % self.snapshots[0],
-                         "Failed to show snapshot "
-                         "status for %s" % self.snapshots[0])
-        g.log.info("Successfully checked snapshot status for %s",
-                   self.snapshots[0])
+        snap_status = redant.get_snap_status_by_snapname(self.snapshots[0],
+                                                         self.server_list[0])
+        if self.snapshots[0] not in snap_status:
+            raise Exception("Failed to show snapshot "
+                            f"status for {self.snapshots[0]}")
 
         # Check snapshot status using volname
-        ret, snap_vol_status, _ = snap_status_by_volname(self.mnode,
-                                                         self.volname)
-        self.assertEqual(ret, 0, ("Failed to get snapshot statue "
-                                  "by volume name"))
-        self.assertIsNotNone(snap_vol_status, "failed to get snap status")
+        snap_vol_sts = redant.get_snap_status_by_volname(self.vol_name,
+                                                         self.server_list[0])
         for snap in self.snapshots:
-            self.assertIn(snap, snap_vol_status,
-                          "Failed to validate snapshot name")
-        g.log.info("Successfully validated snapshot status for %s",
-                   self.volname)
+            if snap not in snap_vol_sts:
+                raise Exception("Failed to validate snapshot status")
 
         # Restart Glusterd on all node
-        ret = restart_glusterd(self.servers)
-        self.assertTrue(ret, "Failed to stop glusterd")
-        g.log.info("Successfully stopped glusterd on all node")
+        redant.restart_glusterd(self.server_list)
 
         # Check Glusterd status
-        ret = is_glusterd_running(self.servers)
-        self.assertEqual(ret, 0, "glusterd running on node ")
-        g.log.info("glusterd is not running")
+        ret = redant.is_glusterd_running(self.server_list)
+        if ret != 1:
+            raise Exception("glusterd is not running")
 
         # Validate snapshot status information
         # Check snapshot status
-        snap_stat = get_snap_status(self.mnode)
-        self.assertIsNotNone(snap_stat, "failed to get snap status")
-        snap_count = 0
+        snap_stat = redant.get_snap_status(self.server_list[0])
         for snap in self.snapshots:
-            self.assertEqual(snap_stat[snap_count]['name'],
-                             snap, "Failed to show snapshot status")
-            snap_count += 1
-        g.log.info("Successfully checked snapshot status")
+            if snap not in snap_stat:
+                raise Exception("Failed to show snapshot status")
 
         # Check snapshot status using snap name
-        snap_status = get_snap_status_by_snapname(self.mnode,
-                                                  self.snapshots[0])
-        self.assertIsNotNone(snap_status, "failed to get snap status")
-        self.assertEqual(snap_status['name'], "%s" % self.snapshots[0],
-                         "Failed to show snapshot "
-                         "status for %s" % self.snapshots[0])
-        g.log.info("Successfully checked snapshot status for %s",
-                   self.snapshots[0])
+        snap_status = redant.get_snap_status_by_snapname(self.snapshots[0],
+                                                         self.server_list[0])
+        if self.snapshots[0] not in snap_status:
+            raise Exception("Failed to show snapshot "
+                            f"status for {self.snapshots[0]}")
 
         # Check snapshot status using volname
-        ret, snap_vol_status, _ = snap_status_by_volname(self.mnode,
-                                                         self.volname)
-        self.assertEqual(ret, 0, ("Failed to get snapshot statue "
-                                  "by volume name"))
-        self.assertIsNotNone(snap_vol_status, "failed to get snap status")
+        snap_vol_sts = redant.get_snap_status_by_volname(self.vol_name,
+                                                         self.server_list[0])
         for snap in self.snapshots:
-            self.assertIn(snap, snap_vol_status,
-                          "Failed to validate snapshot status "
-                          "using volume name")
-        g.log.info("Successfully validated snapshot status for %s",
-                   self.volname)
+            if snap not in snap_vol_sts:
+                raise Exception("Failed to validate snapshot status")

--- a/tests/functional/snapshot/test_snap_status_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_status_glusterd_restart.py
@@ -53,8 +53,8 @@ class TestSnapshotGlusterdRestart(DParentTest):
         # Check snapshot status using snap name
         snap_status = redant.get_snap_status_by_snapname(self.snapshots[0],
                                                          self.server_list[0])
-        if self.snapshots[0] not in snap_status:
-            raise Exception("Failed to show snapshot "
+        if not snap_status:
+            raise Exception("Failed to get snapshot "
                             f"status for {self.snapshots[0]}")
 
         # Check snapshot status using volname
@@ -82,8 +82,8 @@ class TestSnapshotGlusterdRestart(DParentTest):
         # Check snapshot status using snap name
         snap_status = redant.get_snap_status_by_snapname(self.snapshots[0],
                                                          self.server_list[0])
-        if self.snapshots[0] not in snap_status:
-            raise Exception("Failed to show snapshot "
+        if not snap_status:
+            raise Exception("Failed to get snapshot "
                             f"status for {self.snapshots[0]}")
 
         # Check snapshot status using volname

--- a/tests/functional/snapshot/test_snap_status_glusterd_restart.py
+++ b/tests/functional/snapshot/test_snap_status_glusterd_restart.py
@@ -1,0 +1,162 @@
+#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+
+Test Cases in this module tests the
+snapshot Status when glusterd is restarted.
+
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.gluster_base_class import runs_on
+from glustolibs.gluster.gluster_init import (restart_glusterd,
+                                             is_glusterd_running)
+from glustolibs.gluster.snap_ops import (snap_create,
+                                         get_snap_status,
+                                         get_snap_status_by_snapname,
+                                         snap_status_by_volname)
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed', 'distributed-dispersed'],
+          ['glusterfs']])
+class TestSnapshotGlusterdRestart(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.get_super_method(cls, 'setUpClass')()
+        cls.snapshots = [('snap-test-snap-status-gd-restart-%s-%s'
+                          % (cls.volname, i))for i in range(0, 2)]
+
+    def setUp(self):
+
+        # SettingUp volume and Mounting the volume
+        self.get_super_method(self, 'setUp')()
+
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Failed to setup volume %s" % self.volname)
+        g.log.info("Volume %s has been setup successfully", self.volname)
+
+    def tearDown(self):
+
+        # Unmount and cleanup original volume
+
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
+
+    def test_snap_status_glusterd_restart(self):
+        # pylint: disable=too-many-statements, too-many-branches
+        """
+        Test Case:
+        1. Create volume
+        2. Create two snapshots with description
+        3. Check snapshot status informations with snapname, volume name and
+           without snap name/volname.
+        4. Restart glusterd on all nodes
+        5. Follow step3 again and validate snapshot
+        """
+
+        # Creating snapshot with description
+        for snap in self.snapshots:
+            ret, _, _ = snap_create(self.mnode, self.volname, snap,
+                                    description='$p3C!@l C#@R@cT#R$')
+            self.assertEqual(ret, 0, ("Failed to create snapshot for volume %s"
+                                      % self.volname))
+            g.log.info("Snapshot %s created successfully"
+                       " for volume %s", snap, self.volname)
+
+        # Validate snapshot status information
+        # Check snapshot status
+        snap_stat = get_snap_status(self.mnode)
+        self.assertIsNotNone(snap_stat, "failed to get snap status")
+        snap_count = 0
+        for snap in self.snapshots:
+            self.assertEqual(snap_stat[snap_count]['name'],
+                             snap, "Failed to show snapshot status")
+            snap_count += 1
+        g.log.info("Successfully checked snapshot status")
+
+        # Check snapshot status using snap name
+        snap_status = get_snap_status_by_snapname(self.mnode,
+                                                  self.snapshots[0])
+        self.assertIsNotNone(snap_status, "failed to get snap status")
+        self.assertEqual(snap_status['name'], "%s" % self.snapshots[0],
+                         "Failed to show snapshot "
+                         "status for %s" % self.snapshots[0])
+        g.log.info("Successfully checked snapshot status for %s",
+                   self.snapshots[0])
+
+        # Check snapshot status using volname
+        ret, snap_vol_status, _ = snap_status_by_volname(self.mnode,
+                                                         self.volname)
+        self.assertEqual(ret, 0, ("Failed to get snapshot statue "
+                                  "by volume name"))
+        self.assertIsNotNone(snap_vol_status, "failed to get snap status")
+        for snap in self.snapshots:
+            self.assertIn(snap, snap_vol_status,
+                          "Failed to validate snapshot name")
+        g.log.info("Successfully validated snapshot status for %s",
+                   self.volname)
+
+        # Restart Glusterd on all node
+        ret = restart_glusterd(self.servers)
+        self.assertTrue(ret, "Failed to stop glusterd")
+        g.log.info("Successfully stopped glusterd on all node")
+
+        # Check Glusterd status
+        ret = is_glusterd_running(self.servers)
+        self.assertEqual(ret, 0, "glusterd running on node ")
+        g.log.info("glusterd is not running")
+
+        # Validate snapshot status information
+        # Check snapshot status
+        snap_stat = get_snap_status(self.mnode)
+        self.assertIsNotNone(snap_stat, "failed to get snap status")
+        snap_count = 0
+        for snap in self.snapshots:
+            self.assertEqual(snap_stat[snap_count]['name'],
+                             snap, "Failed to show snapshot status")
+            snap_count += 1
+        g.log.info("Successfully checked snapshot status")
+
+        # Check snapshot status using snap name
+        snap_status = get_snap_status_by_snapname(self.mnode,
+                                                  self.snapshots[0])
+        self.assertIsNotNone(snap_status, "failed to get snap status")
+        self.assertEqual(snap_status['name'], "%s" % self.snapshots[0],
+                         "Failed to show snapshot "
+                         "status for %s" % self.snapshots[0])
+        g.log.info("Successfully checked snapshot status for %s",
+                   self.snapshots[0])
+
+        # Check snapshot status using volname
+        ret, snap_vol_status, _ = snap_status_by_volname(self.mnode,
+                                                         self.volname)
+        self.assertEqual(ret, 0, ("Failed to get snapshot statue "
+                                  "by volume name"))
+        self.assertIsNotNone(snap_vol_status, "failed to get snap status")
+        for snap in self.snapshots:
+            self.assertIn(snap, snap_vol_status,
+                          "Failed to validate snapshot status "
+                          "using volume name")
+        g.log.info("Successfully validated snapshot status for %s",
+                   self.volname)


### PR DESCRIPTION
Migrated TC [test_snap_status_glusterd_restart](https://github.com/gluster/glusto-tests/blob/master/tests/functional/snapshot/test_snap_status_glusterd_restart.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>