### PR TITLE
Migrated TC test_snap_scheduler_status

### DIFF
--- a/common/mixin.py
+++ b/common/mixin.py
@@ -21,12 +21,13 @@ from .ops.gluster_ops.auth_ops import AuthOps
 from .ops.gluster_ops.snapshot_ops import SnapshotOps
 from .ops.gluster_ops.glusterfind_ops import GlusterfindOps
 from .ops.gluster_ops.dht_ops import DHTOps
+from .ops.gluster_ops.snap_scheduler_ops import SnapSchedulerOps
 
 
 class RedantMixin(GlusterdOps, VolumeOps, BrickOps, PeerOps,
                   IoOps, MachineOps, MountOps, ProfileOps, RebalanceOps,
                   HealOps, SharedStorageOps, AuthOps, BitrotOps, SnapshotOps,
-                  GlusterfindOps, DHTOps, Rexe, Logger):
+                  GlusterfindOps, DHTOps, SnapSchedulerOps, Rexe, Logger):
     """
     A mixin class for redant project to encompass all ops, support
     modules and encapsulates the object responsible for the framework

--- a/common/ops/gluster_ops/shared_storage_ops.py
+++ b/common/ops/gluster_ops/shared_storage_ops.py
@@ -56,14 +56,15 @@ class SharedStorageOps(AbstractOps):
 
         return True
 
-    def is_shared_volume_mounted_or_unmounted(self, node: str,
-                                              is_mounted=True,
-                                              timeout: int = 20) -> bool:
+    def is_shared_volume_mounted(self, node: str, is_mounted=True,
+                                 timeout: int = 20) -> bool:
         """
         Checks if shared storage volume is mounted
 
         Args:
             node (str) : Node on which command is to be executed
+            is_mounted (bool): True, if the volume is expected to be mounted,
+                               False if it is not expected to be mounted.
         Optional:
             timeout(int) : Maximum time allowed to check for shared volume
 

--- a/common/ops/gluster_ops/snap_scheduler_ops.py
+++ b/common/ops/gluster_ops/snap_scheduler_ops.py
@@ -1,0 +1,114 @@
+"""
+This file contains one class - SnapSchedulerOps wich holds
+operations like enable, disable, init and few others on the snap scheduler
+"""
+from common.ops.abstract_ops import AbstractOps
+
+
+class SnapSchedulerOps(AbstractOps):
+    """
+    SnapSchedulerOps class provides APIs to enable, disable,
+    init and few others on the scheduler ops.
+    """
+    def scheduler_init(self, servers: list) -> bool:
+        """
+        Initialises snapshot scheduler
+
+        Args:
+            servers(list): List of servers on which cmd has to be executed.
+            excep (bool): Whether to handle exception or not.
+                          By default it is True.
+
+        Returns:
+            bool: True on Success, else False on failure
+
+        Example:
+            scheduler_init("abc.com")
+        """
+        if not isinstance(servers, list):
+            servers = [servers]
+
+        cmd = "snap_scheduler.py init"
+        for server in servers:
+            ret = self.execute_abstract_op_node(cmd, server, False)
+            if ret['error_code'] != 0:
+                self.logger.error("Unable to initialize scheduler on "
+                                  f"{server}")
+                return False
+
+        return True
+
+    def scheduler_enable(self, node: str, excep: bool = True) -> dict:
+        """
+        Enables snapshot scheduler on given node
+
+        Args:
+            node (str): Node on which cmd has to be executed.
+            excep (bool): Whether to handle exception or not.
+                          By default it is True.
+
+        Returns:
+            ret: A dictionary consisting
+                - Flag : Flag to check if connection failed
+                - msg : message
+                - error_msg: error message
+                - error_code: error code returned
+                - cmd : command that got executed
+                - node : node on which the command got executed
+
+         Example:
+            scheduler_enable("abc.com")
+        """
+
+        cmd = "snap_scheduler.py enable"
+        return self.execute_abstract_op_node(cmd, node, excep)
+
+    def scheduler_disable(self, node: str, excep: bool = True) -> dict:
+        """
+        Disable snapshot scheduler on given node
+
+        Args:
+            node (str): Node on which cmd has to be executed.
+            excep (bool): Whether to handle exception or not.
+                          By default it is True.
+
+        Returns:
+            ret: A dictionary consisting
+                - Flag : Flag to check if connection failed
+                - msg : message
+                - error_msg: error message
+                - error_code: error code returned
+                - cmd : command that got executed
+                - node : node on which the command got executed
+
+         Example:
+            scheduler_disable("abc.com")
+        """
+
+        cmd = "snap_scheduler.py disable"
+        return self.execute_abstract_op_node(cmd, node, excep)
+
+    def scheduler_status(self, node: str, excep: bool = True) -> dict:
+        """
+        Executes snapshot scheduler status command
+
+        Args:
+            node (str): Node on which cmd has to be executed.
+            excep (bool): Whether to handle exception or not.
+                          By default it is True.
+
+        Returns:
+            ret: A dictionary consisting
+                - Flag : Flag to check if connection failed
+                - msg : message
+                - error_msg: error message
+                - error_code: error code returned
+                - cmd : command that got executed
+                - node : node on which the command got executed
+
+        Example:
+            scheduler_status("abc.xyz.com")
+        """
+
+        cmd = "snap_scheduler.py status"
+        return self.execute_abstract_op_node(cmd, node, excep)

--- a/tests/example/sample_component/test_snap_scheduler_ops.py
+++ b/tests/example/sample_component/test_snap_scheduler_ops.py
@@ -27,16 +27,17 @@ class TestCase(DParentTest):
                     count = 0
                     while count < 40:
                         ret = self.redant.scheduler_status(server, False)
-                        if ret['error_code'] != 0:
-                            break
-                        # status = status.strip().split(":")[2]
-                        # if ret == 0 and status == ' Enabled':
-                        #     break
+                        status = ret['msg'][0].split(':')
+                        if len(status) == 3:
+                            status = status[2].strip()
+                            if ret['error_code'] == 0 \
+                               and status == "Disabled":
+                                break
                         sleep(2)
                         count += 1
-                    if ret['error_code'] == 0:
-                        raise Exception("Unexpected: Status of scheduler"
-                                        f" on node {server} was successfull")
+                    if ret['error_code'] != 0:
+                        raise Exception("Failed to check status of scheduler"
+                                        f" on node {server}")
 
             # Check if shared storage is enabled
             # Disable if true
@@ -96,11 +97,11 @@ class TestCase(DParentTest):
             count = 0
             while count < 40:
                 ret = redant.scheduler_status(server, False)
-                if ret['error_code'] == 0:
-                    break
-                # status = status.strip().split(":")[2]
-                # if ret == 0 and status == ' Enabled':
-                #     break
+                status = ret['msg'][0].split(':')
+                if len(status) == 3:
+                    status = status[2].strip()
+                    if ret['error_code'] == 0 and status == "Enabled":
+                        break
                 sleep(2)
                 count += 1
             if ret['error_code'] != 0:
@@ -115,14 +116,14 @@ class TestCase(DParentTest):
         for server in self.server_list:
             count = 0
             while count < 40:
-                ret = redant.scheduler_status(server, False)
-                if ret['error_code'] != 0:
-                    break
-                # status = status.strip().split(":")[2]
-                # if ret == 0 and status == ' Enabled':
-                #     break
+                ret = self.redant.scheduler_status(server, False)
+                status = ret['msg'][0].split(':')
+                if len(status) == 3:
+                    status = status[2].strip()
+                    if ret['error_code'] == 0 and status == "Disabled":
+                        break
                 sleep(2)
                 count += 1
-            if ret['error_code'] == 0:
-                raise Exception("Unexpected: Status of scheduler"
-                                f" on node {server} was successfull")
+            if ret['error_code'] != 0:
+                raise Exception("Failed to check status of scheduler"
+                                f" on node {server}")

--- a/tests/example/sample_component/test_snap_scheduler_ops.py
+++ b/tests/example/sample_component/test_snap_scheduler_ops.py
@@ -1,0 +1,128 @@
+"""
+This file contains a test-case which tests
+the SnapSchedulerOps ops.
+"""
+
+# disruptive;rep,dist,dist-rep,arb,dist-arb,disp,dist-disp
+import traceback
+from time import sleep
+from tests.d_parent_test import DParentTest
+
+
+class TestCase(DParentTest):
+    """
+    SnapScheduler related testing.
+    """
+    def terminate(self):
+        """
+        Disable shared storage and snap_scheduler
+        """
+        try:
+            if self.is_scheduler_enabled:
+                # Disable snap scheduler
+                self.redant.scheduler_disable(self.server_list[0], False)
+
+                # Check snapshot scheduler status
+                for server in self.server_list:
+                    count = 0
+                    while count < 40:
+                        ret = self.redant.scheduler_status(server, False)
+                        if ret['error_code'] != 0:
+                            break
+                        # status = status.strip().split(":")[2]
+                        # if ret == 0 and status == ' Enabled':
+                        #     break
+                        sleep(2)
+                        count += 1
+                    if ret['error_code'] == 0:
+                        raise Exception("Unexpected: Status of scheduler"
+                                        f" on node {server} was successfull")
+
+            # Check if shared storage is enabled
+            # Disable if true
+            ret = self.redant.is_shared_volume_mounted(self.server_list)
+            if ret:
+                ret = self.redant.disable_shared_storage(self.server_list[0])
+                if not ret:
+                    raise Exception("Failed to disable shared storage")
+
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
+
+    def run_test(self, redant):
+        """
+        In the testcase:
+        Steps:
+        1. Enable shared storage
+        2. Check if the shared storage is enabled
+        3. Initalize snap_scheduler
+        4. Enable snap_scheduler
+        5. Check snap_scheduler status
+        6. Disable snap_scheduler
+        """
+        self.is_scheduler_enabled = False
+
+        # Enable shared storage
+        ret = redant.enable_shared_storage(self.server_list[0])
+        if not ret:
+            raise Exception("Failed to enable shared storage")
+
+        # Validate shared storage volume is mounted
+        ret = redant.is_shared_volume_mounted(self.server_list[0], timeout=10)
+        if not ret:
+            raise Exception("Failed to validate if shared volume is mounted")
+
+        # Initialise snap_scheduler on all nodes
+        count = 0
+        sleep(2)
+        while count < 40:
+            ret = redant.scheduler_init(self.server_list)
+            if ret:
+                break
+            sleep(2)
+            count += 1
+        if not ret:
+            raise Exception("Failed to initialize scheduler on all nodes")
+
+        # Enable snap_scheduler
+        redant.scheduler_enable(self.server_list[0])
+        self.is_scheduler_enabled = True
+
+        # Check snapshot scheduler status
+        for server in self.server_list:
+            count = 0
+            while count < 40:
+                ret = redant.scheduler_status(server, False)
+                if ret['error_code'] == 0:
+                    break
+                # status = status.strip().split(":")[2]
+                # if ret == 0 and status == ' Enabled':
+                #     break
+                sleep(2)
+                count += 1
+            if ret['error_code'] != 0:
+                raise Exception("Failed to check status of scheduler"
+                                f" on node {server}")
+
+        # Disable snap scheduler
+        redant.scheduler_disable(self.server_list[0], False)
+        self.is_scheduler_enabled = False
+
+        # Check snapshot scheduler status
+        for server in self.server_list:
+            count = 0
+            while count < 40:
+                ret = redant.scheduler_status(server, False)
+                if ret['error_code'] != 0:
+                    break
+                # status = status.strip().split(":")[2]
+                # if ret == 0 and status == ' Enabled':
+                #     break
+                sleep(2)
+                count += 1
+            if ret['error_code'] == 0:
+                raise Exception("Unexpected: Status of scheduler"
+                                f" on node {server} was successfull")

--- a/tests/functional/glusterd/test_shared_storage.py
+++ b/tests/functional/glusterd/test_shared_storage.py
@@ -77,8 +77,7 @@ class TestSharedStorage(DParentTest):
         """
         for brick in brick_details:
             node = brick.split(":")[0]
-            ret = self.redant.is_shared_volume_mounted_or_unmounted(node,
-                                                                    mounted)
+            ret = self.redant.is_shared_volume_mounted(node, mounted)
             if mounted and not ret:
                 raise Exception("Shared volume not mounted even after "
                                 "enabling it")

--- a/tests/functional/snapshot/test_snap_scheduler_status.py
+++ b/tests/functional/snapshot/test_snap_scheduler_status.py
@@ -1,0 +1,166 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Description:
+    Test Cases in this module tests the
+    snapshot scheduler behavior when shared volume is mounted/not
+    mounted. scheduler command such as initialise scheduler,
+    enable scheduler, status of scheduler.
+"""
+import time
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass,
+                                                   runs_on)
+from glustolibs.gluster.volume_ops import get_volume_options
+from glustolibs.gluster.snap_scheduler import (scheduler_init,
+                                               scheduler_enable,
+                                               scheduler_status,
+                                               scheduler_disable)
+from glustolibs.gluster.shared_storage_ops import (enable_shared_storage,
+                                                   is_shared_volume_mounted,
+                                                   is_shared_volume_unmounted,
+                                                   disable_shared_storage)
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed', 'distributed-dispersed'],
+          ['glusterfs']])
+class SnapshotSchedulerStatus(GlusterBaseClass):
+
+    def setUp(self):
+
+        # SettingUp volume and Mounting the volume
+        GlusterBaseClass.setUp.im_func(self)
+        g.log.info("Starting to SetUp and Mount Volume")
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume %s" % self.volname)
+        g.log.info("Volume %s has been setup successfully", self.volname)
+
+    def tearDown(self):
+
+        # Unmount and cleanup-volume
+        g.log.info("Starting to Unmount and cleanup-volume")
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Unmount and Cleanup Volume")
+        g.log.info("Successful in Unmount Volume and Cleanup Volume")
+
+    def test_snap_scheduler_status(self):
+        # pylint: disable=too-many-statements
+        """
+        Steps:
+        1. create volumes
+        2. initialise snap scheduler without
+           enabling shared storage should fail
+        3. enable shared storage
+        4. initialise snap scheduler
+        5. check snapshot scheduler status
+        """
+        # Validate shared storage is enabled
+        g.log.info("Starting to validate shared storage volume")
+        volinfo = get_volume_options(self.mnode, self.volname,
+                                     option=("cluster.enable"
+                                             "-shared-storage"))
+        if volinfo["cluster.enable-shared-storage"] == "disable":
+            # Initialise snapshot scheduler
+            g.log.info("Initialising snapshot scheduler on all nodes")
+            ret = scheduler_init(self.servers)
+            self.assertFalse(ret, "Unexpected: Successfully initialized "
+                             "scheduler on all nodes")
+            g.log.info("As Expected, Failed to initialize scheduler on "
+                       "all nodes")
+        self.assertEqual(volinfo["cluster.enable-shared-storage"],
+                         "disable", "Unexpected: Shared storage "
+                         "is enabled on cluster")
+
+        # Enable Shared storage
+        g.log.info("enabling shared storage")
+        ret = enable_shared_storage(self.mnode)
+        self.assertTrue(ret, "Failed to enable shared storage")
+        g.log.info("Successfully enabled shared storage")
+
+        # Validate shared storage mounted
+        g.log.info("validate shared storage mounted")
+        ret = is_shared_volume_mounted(self.mnode)
+        self.assertTrue(ret, "Failed to mount shared volume")
+        g.log.info("Successfully mounted shared volume")
+
+        # Validate shared storage volume is enabled
+        g.log.info("validate shared storage volume")
+        volinfo = get_volume_options(self.mnode, self.volname,
+                                     option=("cluster.enable"
+                                             "-shared-storage"))
+        self.assertIsNotNone(volinfo, "Failed to validate volume option")
+        self.assertEqual(volinfo["cluster.enable-shared-storage"], "enable",
+                         "Failed to enable shared storage volume")
+        g.log.info("Shared storage enabled successfully")
+
+        # Initialise snap scheduler
+        g.log.info("Initialising snapshot scheduler on all nodes")
+        count = 0
+        while count < 40:
+            ret = scheduler_init(self.servers)
+            if ret:
+                break
+            time.sleep(2)
+            count += 1
+        self.assertTrue(ret, "Failed to initialize scheduler on all nodes")
+        g.log.info("Successfully initialized scheduler on all nodes")
+
+        # Enable snap scheduler
+        g.log.info("Enabling snap scheduler")
+        ret, _, _ = scheduler_enable(self.mnode)
+        self.assertEqual(ret, 0, "Failed to enable scheduler on %s node" %
+                         self.mnode)
+        g.log.info("Successfully enabled scheduler on %s node", self.mnode)
+
+        # Check snapshot scheduler status
+        g.log.info("checking status of snapshot scheduler")
+        for server in self.servers:
+            count = 0
+            while count < 40:
+                ret, status, _ = scheduler_status(server)
+                if ret == 0:
+                    self.assertEqual(status.strip().split(":")[2], ' Enabled',
+                                     "Failed to check status of scheduler")
+                    break
+                time.sleep(2)
+                count += 1
+            self.assertEqual(ret, 0, "Failed to check status of scheduler"
+                             " on nodes %s" % server)
+            g.log.info("Successfully checked scheduler status on %s nodes",
+                       server)
+
+        # disable snap scheduler
+        g.log.info("disabling snap scheduler")
+        ret, _, _ = scheduler_disable(self.mnode)
+        self.assertEqual(ret, 0, "Unexpected: Failed to disable "
+                         "snapshot scheduler")
+        g.log.info("Successfully disabled snapshot scheduler")
+
+        # disable shared storage
+        g.log.info("starting to disable shared storage")
+        ret = disable_shared_storage(self.mnode)
+        self.assertTrue(ret, "Failed to disable shared storage")
+        g.log.info("Successfully disabled shared storage")
+
+        # Validate shared volume unmounted
+        g.log.info("Validate shared volume unmounted")
+        ret = is_shared_volume_unmounted(self.mnode)
+        self.assertTrue(ret, "Failed to unmount shared storage")
+        g.log.info("Successfully unmounted shared storage")

--- a/tests/functional/snapshot/test_snap_scheduler_status.py
+++ b/tests/functional/snapshot/test_snap_scheduler_status.py
@@ -41,16 +41,16 @@ class TestSnapshotSchedulerStatus(DParentTest):
                 count = 0
                 while count < 40:
                     ret = self.redant.scheduler_status(server, False)
-                    if ret['error_code'] != 0:
-                        break
-                    # status = status.strip().split(":")[2]
-                    # if ret == 0 and status == ' Enabled':
-                    #     break
+                    status = ret['msg'][0].split(':')
+                    if len(status) == 3:
+                        status = status[2].strip()
+                        if ret['error_code'] == 0 and status == "Disabled":
+                            break
                     sleep(2)
                     count += 1
-                if ret['error_code'] == 0:
-                    raise Exception("Unexpected: Status of scheduler"
-                                    f" on node {server} was successfull")
+                if ret['error_code'] != 0:
+                    raise Exception("Failed to check status of scheduler"
+                                    f" on node {server}")
 
             # Check if shared storage is enabled
             # Disable if true
@@ -124,11 +124,11 @@ class TestSnapshotSchedulerStatus(DParentTest):
             count = 0
             while count < 40:
                 ret = redant.scheduler_status(server, False)
-                if ret['error_code'] == 0:
-                    break
-                # status = status.strip().split(":")[2]
-                # if ret == 0 and status == ' Enabled':
-                #     break
+                status = ret['msg'][0].split(':')
+                if len(status) == 3:
+                    status = status[2].strip()
+                    if ret['error_code'] == 0 and status == "Enabled":
+                        break
                 sleep(2)
                 count += 1
             if ret['error_code'] != 0:

--- a/tests/functional/snapshot/test_snap_scheduler_status.py
+++ b/tests/functional/snapshot/test_snap_scheduler_status.py
@@ -43,7 +43,7 @@ class SnapshotSchedulerStatus(GlusterBaseClass):
         """
 
         # SettingUp volume and Mounting the volume
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         g.log.info("Starting to SetUp Volume")
         ret = self.setup_volume()
         if not ret:
@@ -74,7 +74,7 @@ class SnapshotSchedulerStatus(GlusterBaseClass):
         g.log.info("Successful in Cleanup Volume")
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_snap_scheduler_status(self):
         # pylint: disable=too-many-statements

--- a/tests/functional/snapshot/test_snap_scheduler_status.py
+++ b/tests/functional/snapshot/test_snap_scheduler_status.py
@@ -1,191 +1,136 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to verify the snap_scheduler functionality WRT the status
+    and shared storage
+"""
+
+# disruptive;rep,dist-rep,disp,dist,dist-disp
+import traceback
 from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import get_volume_options
-from glustolibs.gluster.snap_scheduler import (scheduler_init,
-                                               scheduler_enable,
-                                               scheduler_status,
-                                               scheduler_disable)
-from glustolibs.gluster.shared_storage_ops import (enable_shared_storage,
-                                                   is_shared_volume_mounted,
-                                                   disable_shared_storage)
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed', 'distributed-dispersed'],
-          ['glusterfs']])
-class SnapshotSchedulerStatus(GlusterBaseClass):
-    """
-    SnapshotSchedulerStatus includes tests which verify the snap_scheduler
-    functionality WRT the status and shared storage
-    """
+class TestSnapshotSchedulerStatus(DParentTest):
 
-    def setUp(self):
+    def terminate(self):
         """
-        setup volume for the test
+        Disable shared storage and snap_scheduler
         """
+        try:
+            # Disable snap scheduler
+            self.redant.scheduler_disable(self.server_list[0], False)
 
-        # SettingUp volume and Mounting the volume
-        self.get_super_method(self, 'setUp')()
-        g.log.info("Starting to SetUp Volume")
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Failed to setup volume %s" % self.volname)
-        g.log.info("Volume %s has been setup successfully", self.volname)
+            # Check snapshot scheduler status
+            for server in self.server_list:
+                count = 0
+                while count < 40:
+                    ret = self.redant.scheduler_status(server, False)
+                    if ret['error_code'] != 0:
+                        break
+                    # status = status.strip().split(":")[2]
+                    # if ret == 0 and status == ' Enabled':
+                    #     break
+                    sleep(2)
+                    count += 1
+                if ret['error_code'] == 0:
+                    raise Exception("Unexpected: Status of scheduler"
+                                    f" on node {server} was successfull")
 
-    def tearDown(self):
+            # Check if shared storage is enabled
+            # Disable if true
+            ret = self.redant.is_shared_volume_mounted(self.server_list)
+            if ret:
+                ret = self.redant.disable_shared_storage(self.server_list[0])
+                if not ret:
+                    raise Exception("Failed to disable shared storage")
+
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
+
+    def run_test(self, redant):
         """
-        tearDown for every test
-        """
-
-        # disable snap scheduler
-        g.log.info("disabling snap scheduler")
-        ret, _, _ = scheduler_disable(self.mnode)
-        self.assertEqual(ret, 0, "Unexpected: Failed to disable "
-                         "snapshot scheduler")
-        g.log.info("Successfully disabled snapshot scheduler")
-
-        # Check snapshot scheduler status
-        g.log.info("checking status of snapshot scheduler")
-        for server in self.servers:
-            count = 0
-            while count < 40:
-                ret, status, _ = scheduler_status(server)
-                status = status.strip().split(":")[2]
-                if not ret and status == ' Disabled':
-                    break
-                sleep(2)
-                count += 1
-            self.assertEqual(ret, 0, "Failed to check status of scheduler"
-                             " on node %s" % server)
-            g.log.info("Successfully checked scheduler status on %s nodes",
-                       server)
-
-        # Check if shared storage is enabled
-        # Disable if true
-        g.log.info("Checking if shared storage is mounted")
-        ret = is_shared_volume_mounted(self.mnode)
-        if ret:
-            g.log.info("Disabling shared storage")
-            ret = disable_shared_storage(self.mnode)
-            if not ret:
-                raise ExecutionError("Failed to disable shared storage")
-            g.log.info("Successfully disabled shared storage")
-
-        # Unmount and cleanup-volume
-        g.log.info("Starting to cleanup-volume")
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Cleanup Volume %s" % self.volname)
-        g.log.info("Successful in Cleanup Volume")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_snap_scheduler_status(self):
-        # pylint: disable=too-many-statements
-        """
-        Validating the snapshot scheduler behavior when shared storage
-        volume is mounted/not mounted.
-
+        Steps:
         * Initialise snap_scheduler without enabling shared storage
         * Enable shared storage
         * Initialise snap_scheduler on all nodes
         * Check snap_scheduler status
         """
-
         # Validate shared storage is disabled
-        g.log.info("Validating shared storage is disabled")
-        volinfo = get_volume_options(self.mnode, self.volname,
-                                     option=("cluster.enable-shared-storage"))
+        option = "cluster.enable-shared-storage"
+        volinfo = redant.get_volume_options(self.vol_name, option,
+                                            self.server_list[0])
         if volinfo["cluster.enable-shared-storage"] == "disable":
             # Initialise snapshot scheduler
-            g.log.info("Initialising snapshot scheduler on all nodes")
-            ret = scheduler_init(self.servers)
-            self.assertFalse(ret, "Unexpected: Successfully initialized "
-                             "scheduler on all nodes")
-            g.log.info("Expected: Failed to initialize snap_scheduler on "
-                       "all nodes")
-        self.assertEqual(volinfo["cluster.enable-shared-storage"],
-                         "disable", "Unexpected: Shared storage "
-                         "is enabled on cluster")
+            ret = redant.scheduler_init(self.server_list)
+            if ret:
+                raise Exception("Unexpected: Successfully initialized "
+                                "scheduler on all nodes")
+        else:
+            raise Exception("Unexpected: Shared storage enabled on cluster")
 
         # Enable shared storage
-        g.log.info("enabling shared storage")
-        ret = enable_shared_storage(self.mnode)
-        self.assertTrue(ret, "Failed to enable shared storage")
-        g.log.info("Successfully enabled shared storage")
+        ret = redant.enable_shared_storage(self.server_list[0])
+        if not ret:
+            raise Exception("Failed to enable shared storage")
 
         # Validate shared storage volume is mounted
-        g.log.info("Validating if shared storage volume is mounted")
-        count = 0
-        while count < 5:
-            ret = is_shared_volume_mounted(self.mnode)
-            if ret:
-                break
-            sleep(2)
-            count += 1
-        self.assertTrue(ret, "Failed to validate if shared volume is mounted")
-        g.log.info("Successfully validated shared volume is mounted")
+        ret = redant.is_shared_volume_mounted(self.server_list[0], timeout=10)
+        if not ret:
+            raise Exception("Failed to validate if shared volume is mounted")
 
         # Validate shared storage volume is enabled
-        g.log.info("Validate shared storage is enabled")
-        volinfo = get_volume_options(self.mnode, self.volname,
-                                     option=("cluster.enable-shared-storage"))
-        self.assertIsNotNone(volinfo, "Failed to validate volume option")
-        self.assertEqual(volinfo["cluster.enable-shared-storage"], "enable",
-                         "Failed to validate if shared storage is enabled")
-        g.log.info("Successfully validated shared storage is enabled")
+        option = "cluster.enable-shared-storage"
+        volinfo = redant.get_volume_options(self.vol_name, option,
+                                            self.server_list[0])
+        if volinfo["cluster.enable-shared-storage"] != "enable":
+            raise Exception("Failed to validate if shared storage is enabled")
 
         # Initialise snap_scheduler on all nodes
-        g.log.info("Initialising snapshot scheduler on all nodes")
         count = 0
         sleep(2)
         while count < 40:
-            ret = scheduler_init(self.servers)
+            ret = redant.scheduler_init(self.server_list)
             if ret:
                 break
             sleep(2)
             count += 1
-        self.assertTrue(ret, "Failed to initialize scheduler on all nodes")
-        g.log.info("Successfully initialized scheduler on all nodes")
+        if not ret:
+            raise Exception("Failed to initialize scheduler on all nodes")
 
         # Enable snap_scheduler
-        g.log.info("Enabling snap_scheduler")
-        ret, _, _ = scheduler_enable(self.mnode)
-        self.assertEqual(ret, 0, "Failed to enable scheduler on %s node" %
-                         self.mnode)
-        g.log.info("Successfully enabled scheduler on %s node", self.mnode)
+        redant.scheduler_enable(self.server_list[0])
 
         # Check snapshot scheduler status
-        g.log.info("checking status of snapshot scheduler")
-        for server in self.servers:
+        for server in self.server_list:
             count = 0
             while count < 40:
-                ret, status, _ = scheduler_status(server)
-                status = status.strip().split(":")[2]
-                if ret == 0 and status == ' Enabled':
+                ret = redant.scheduler_status(server, False)
+                if ret['error_code'] == 0:
                     break
+                # status = status.strip().split(":")[2]
+                # if ret == 0 and status == ' Enabled':
+                #     break
                 sleep(2)
                 count += 1
-            self.assertEqual(ret, 0, "Failed to check status of scheduler"
-                             " on node %s" % server)
-            g.log.info("Successfully checked scheduler status on %s nodes",
-                       server)
+            if ret['error_code'] != 0:
+                raise Exception("Failed to check status of scheduler"
+                                f" on node {server}")


### PR DESCRIPTION
Migrated TC [test_snap_scheduler_status](https://github.com/gluster/glusto-tests/blob/master/tests/functional/snapshot/test_snap_scheduler_status.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>