### PR TITLE
Fix f-string and object name

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -69,3 +69,4 @@ excluded_tests:
     - tests/functional/snapshot/test_256_snapshots.py # Requires baremetal servers with multiple disks and good amount of RAM, to create these many snapshots
     - tests/functional/snapshot/test_snap_delete_multiple.py # Requires good servers with high amount of RAM and multiple disks
     - tests/functional/snapshot/test_validate_snapshot_max_limit.py # Requires good servers with high amount of RAM and multiple disks
+    - tests/functional/snapshot/test_validate_snap_del_gd_down.py # Requires downstream RHGS installation

--- a/tests/functional/arbiter/test_data_self_heal_algorithm_diff_heal_command.py
+++ b/tests/functional/arbiter/test_data_self_heal_algorithm_diff_heal_command.py
@@ -62,7 +62,7 @@ class TestSelfHeal(DParentTest):
 
         # Creating files on client side
         mount_dict = []
-        cmd = ("python3 {script_file_path} create_files -f 100 "
+        cmd = (f"python3 {script_file_path} create_files -f 100 "
                f"{self.mountpoint}")
 
         proc = redant.execute_command_async(cmd, self.client_list[0])
@@ -93,7 +93,7 @@ class TestSelfHeal(DParentTest):
             raise Exception(f"Bricks {offline_brick_list} are not offline")
 
         # Modify the data
-        cmd = ("python3 {script_file_path} create_files -f 100 "
+        cmd = (f"python3 {script_file_path} create_files -f 100 "
                f" --fixed-file-size 1M {self.mountpoint}")
 
         proc = redant.execute_command_async(cmd, self.client_list[0])

--- a/tests/functional/arbiter/test_entry_self_heal_heal_command.py
+++ b/tests/functional/arbiter/test_entry_self_heal_heal_command.py
@@ -73,10 +73,10 @@ class TestSelfHeal(DParentTest):
         # Command list to do different operations with data -
         # create, rename, copy and delete
         cmds = (
-            ("python3 {script_file_path} create_files -f 20 "
+            (f"python3 {script_file_path} create_files -f 20 "
              f"{self.mountpoint}/files"),
             f"python3 {script_file_path} mv {self.mountpoint}/files",
-            ("python3 {script_file_path} copy --dest-dir "
+            (f"python3 {script_file_path} copy --dest-dir "
              f"{self.mountpoint}/new_dir {self.mountpoint}/files"),
             f"python3 {script_file_path} delete {self.mountpoint}",
         )

--- a/tests/functional/glusterfind/test_glusterfind_when_node_down.py
+++ b/tests/functional/glusterfind/test_glusterfind_when_node_down.py
@@ -177,7 +177,7 @@ class TestGlusterFindNodeDown(DParentTest):
         while counter < timeout:
             ret = redant.are_nodes_online(self.random_server)
             if not ret:
-                self.logger.info("Node's offline, Retrying after 5 seconds..")
+                redant.logger.info("Node's offline, Retrying after 5 seconds..")
                 sleep(5)
                 counter += 5
             else:

--- a/tests/functional/glusterfind/test_glusterfind_when_node_down.py
+++ b/tests/functional/glusterfind/test_glusterfind_when_node_down.py
@@ -177,7 +177,7 @@ class TestGlusterFindNodeDown(DParentTest):
         while counter < timeout:
             ret = redant.are_nodes_online(self.random_server)
             if not ret:
-                redant.logger.info("Node's offline, Retrying after 5 seconds..")
+                redant.logger.info("Node's offline, Retrying after 5 seconds")
                 sleep(5)
                 counter += 5
             else:


### PR DESCRIPTION
**Description:**

Fixed `f-string` issue for a few TCs.
Updated the object name to be `redant` in one TC
Marked a TC as excluded as it works only in downstream RHGS code

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
