### PR TITLE
Migrated TC test_nonfop_ecversion

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -1461,17 +1461,18 @@ class BrickOps(AbstractOps):
             return None
 
         attr_dict = {}
-        # for each_attr in ret['msg'].split('\n\n')[:-1]:
-        #     for line in each_attr.split('\n'):
-        #         if line.startswith('#'):
-        #             match = re.search(r'.*file:\s(\S+).*', line)
-        #             if match is None:
-        #                 self.logger.error("getfattr output is not in expected"
-        #                                   " format")
-        #                 return None
-        #             key = "/" + match.group(1)
-        #             attr_dict[key] = {}
-        #         else:
-        #             output = line.split('=')
-        #             attr_dict[key][output[0]] = output[1]
+        for each_attr in ret['msg'][:-1]:
+            line = each_attr.strip()
+            if line:
+                if line.startswith('#'):
+                    match = re.search(r'.*file:\s(\S+).*', line)
+                    if match is None:
+                        self.logger.error("getfattr output is not in expected"
+                                          " format")
+                        return None
+                    key = "/" + match.group(1)
+                    attr_dict[key] = {}
+                else:
+                    output = line.split('=')
+                    attr_dict[key][output[0]] = output[1].strip()
         return attr_dict

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -5,6 +5,7 @@ Brick ops module deals with the functions related to brick related operations.
 
 from time import sleep
 import random
+import re
 from common.ops.abstract_ops import AbstractOps
 
 
@@ -1424,3 +1425,53 @@ class BrickOps(AbstractOps):
         if volume_bricks_to_bring_offline == []:
             return None
         return volume_bricks_to_bring_offline
+
+    def get_extended_attributes_info(self, node: str, file_list: list,
+                                     encoding: str = 'hex',
+                                     attr_name: str = '') -> dict:
+        """
+        Function to get extended attribute info for the given file list
+
+        Args:
+            node (str): Node on which cmd has to be executed.
+            file_list (list): absolute file names for which extended
+                              attributes to be fetched
+
+        Optional:
+            encoding (str): encoding format
+            attr_name (str): extended attribute name
+
+        Returns:
+            NoneType: None if command execution fails, parse errors.
+            dict: extended attribute for each file in the given file list
+        """
+        if not isinstance(file_list, list):
+            file_list = [file_list]
+
+        if attr_name == '':
+            cmd = f"getfattr -d -m . -e {encoding} {' '.join(file_list)}"
+        else:
+            cmd = (f"getfattr -d -m . -e {encoding} -n {attr_name} "
+                   f"{' '.join(file_list)}")
+
+        ret = self.execute_abstract_op_node(cmd, node, False)
+        if ret['error_code'] != 0:
+            self.logger.error("Failed to execute getfattr command on server"
+                              f" {node}")
+            return None
+
+        attr_dict = {}
+        # for each_attr in ret['msg'].split('\n\n')[:-1]:
+        #     for line in each_attr.split('\n'):
+        #         if line.startswith('#'):
+        #             match = re.search(r'.*file:\s(\S+).*', line)
+        #             if match is None:
+        #                 self.logger.error("getfattr output is not in expected"
+        #                                   " format")
+        #                 return None
+        #             key = "/" + match.group(1)
+        #             attr_dict[key] = {}
+        #         else:
+        #             output = line.split('=')
+        #             attr_dict[key][output[0]] = output[1]
+        return attr_dict

--- a/tests/functional/disperse/test_nonfop_ecversion.py
+++ b/tests/functional/disperse/test_nonfop_ecversion.py
@@ -1,115 +1,86 @@
-#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-Test Description:
+ Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
     Tests bricks EC version on a EC vol
     Don't send final version update if non data fop succeeded validation
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import (GlusterBaseClass, runs_on)
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.brick_libs import (get_all_bricks)
-from glustolibs.gluster.lib_utils import (get_extended_attributes_info)
+
+# disruptive;disp
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['dispersed'],
-          ['glusterfs']])
-class TestEcVersion(GlusterBaseClass):
+class TestEcVersion(DParentTest):
 
-    def setUp(self):
-        # Calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        self.all_mounts_procs = []
-        self.io_validation_complete = False
-
-        # Setup Volume and Mount Volume
-        g.log.info("Starting to Setup Volume and Mount Volume")
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts,
-                                                 volume_create_force=False)
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
-        g.log.info("Successful in Setup Volume and Mount Volume")
-
-    def tearDown(self):
+    def run_test(self, redant):
         """
-        Cleanup and umount volume
+        Steps:
+        - Get the brick list for the volume
+        - Create a dir 'dir1' on mountpoint
+        - Get the EC version of the directory
+        - Update permission of the directory
+        - Again update permissions
+        - Get the EC version of the directory
+        - Compare EC version before and after non data FOP, should be equal
         """
-
-        # Cleanup and umount volume
-        g.log.info("Starting to Unmount Volume and Cleanup Volume")
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-        # Calling GlusterBaseClass teardown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_ec_version_nonfop(self):
-        # pylint: disable=too-many-statements,too-many-branches,too-many-locals
-
-        # get the bricks from the volume
-        g.log.info("Fetching bricks for the volume : %s", self.volname)
-        bricks_list = get_all_bricks(self.mnode, self.volname)
-        g.log.info("Brick List : %s", bricks_list)
+        # Get the bricks from the volume
+        bricks_list = redant.get_all_bricks(self.vol_name,
+                                            self.server_list[0])
+        if not bricks_list:
+            raise Exception("Failed to get the brick list")
 
         # Creating dir1 on the mountpoint
-        cmd = ('mkdir %s/dir1' % self.mounts[0].mountpoint)
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Failed to create directory dir1")
-        g.log.info("Directory dir1 on %s created successfully",
-                   self.mounts[0])
+        redant.create_dir(self.mountpoint, "dir1", self.client_list[0])
 
         ec_version_before_nonfops = []
         ec_version_after_nonfops = []
         # Getting the EC version of the directory
         for brick in bricks_list:
             brick_node, brick_path = brick.split(":")
-            target_file = brick_path + "/dir1"
-            dir_attribute = get_extended_attributes_info(brick_node,
-                                                         [target_file])
-            ec_version_before_nonfops.append(dir_attribute
-                                             [target_file]
-                                             ['trusted.ec.version'])
+            target_file = f"{brick_path}/dir1"
+            dir_attribute = redant.get_extended_attributes_info(brick_node,
+                                                                target_file)
+            if not dir_attribute:
+                raise Exception("Failed to get extended attributes")
+
+            ec_vers = dir_attribute[target_file]['trusted.ec.version']
+            ec_version_before_nonfops.append(ec_vers)
 
         # chmod of dir1 once
-        cmd = ('chmod 777 %s/dir1'
-               % (self.mounts[0].mountpoint))
-        g.run(self.mounts[0].client_system, cmd)
+        cmd = f"chmod 777 {self.mountpoint}/dir1"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # chmod of dir1 twice
-        cmd = ('chmod 777 %s/dir1'
-               % (self.mounts[0].mountpoint))
-        g.run(self.mounts[0].client_system, cmd)
+        cmd = f"chmod 777 {self.mountpoint}/dir1"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Getting the EC version of the directory
         # After changing mode of the directory
         for brick in bricks_list:
             brick_node, brick_path = brick.split(":")
-            target_file = brick_path + "/dir1"
-            dir_attribute = get_extended_attributes_info(brick_node,
-                                                         [target_file])
-            ec_version_after_nonfops.append(dir_attribute
-                                            [target_file]
-                                            ['trusted.ec.version'])
+            target_file = f"{brick_path}/dir1"
+            dir_attribute = redant.get_extended_attributes_info(brick_node,
+                                                                target_file)
+            if not dir_attribute:
+                raise Exception("Failed to get extended attributes")
+
+            ec_vers = dir_attribute[target_file]['trusted.ec.version']
+            ec_version_after_nonfops.append(ec_vers)
 
         # Comparing the EC version before and after non data FOP
-        self.assertEqual(ec_version_before_nonfops, ec_version_after_nonfops,
-                         "EC version updated for non data FOP")
-        g.log.info("EC version is same for before and after non data FOP"
-                   "%s", self.volname)
+        if ec_version_before_nonfops != ec_version_after_nonfops:
+            raise Exception("EC version updated for non data FOP")

--- a/tests/functional/disperse/test_nonfop_ecversion.py
+++ b/tests/functional/disperse/test_nonfop_ecversion.py
@@ -32,7 +32,7 @@ class TestEcVersion(GlusterBaseClass):
 
     def setUp(self):
         # Calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         self.all_mounts_procs = []
         self.io_validation_complete = False
@@ -58,7 +58,7 @@ class TestEcVersion(GlusterBaseClass):
         g.log.info("Successful in umounting the volume and Cleanup")
 
         # Calling GlusterBaseClass teardown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_ec_version_nonfop(self):
         # pylint: disable=too-many-statements,too-many-branches,too-many-locals

--- a/tests/functional/disperse/test_nonfop_ecversion.py
+++ b/tests/functional/disperse/test_nonfop_ecversion.py
@@ -1,0 +1,115 @@
+#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Test Description:
+    Tests bricks EC version on a EC vol
+    Don't send final version update if non data fop succeeded validation
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass, runs_on)
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.brick_libs import (get_all_bricks)
+from glustolibs.gluster.lib_utils import (get_extended_attributes_info)
+
+
+@runs_on([['dispersed'],
+          ['glusterfs']])
+class TestEcVersion(GlusterBaseClass):
+
+    def setUp(self):
+        # Calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+
+        self.all_mounts_procs = []
+        self.io_validation_complete = False
+
+        # Setup Volume and Mount Volume
+        g.log.info("Starting to Setup Volume and Mount Volume")
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts,
+                                                 volume_create_force=False)
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
+        g.log.info("Successful in Setup Volume and Mount Volume")
+
+    def tearDown(self):
+        """
+        Cleanup and umount volume
+        """
+
+        # Cleanup and umount volume
+        g.log.info("Starting to Unmount Volume and Cleanup Volume")
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
+
+        # Calling GlusterBaseClass teardown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_ec_version_nonfop(self):
+        # pylint: disable=too-many-statements,too-many-branches,too-many-locals
+
+        # get the bricks from the volume
+        g.log.info("Fetching bricks for the volume : %s", self.volname)
+        bricks_list = get_all_bricks(self.mnode, self.volname)
+        g.log.info("Brick List : %s", bricks_list)
+
+        # Creating dir1 on the mountpoint
+        cmd = ('mkdir %s/dir1' % self.mounts[0].mountpoint)
+        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
+        self.assertEqual(ret, 0, "Failed to create directory dir1")
+        g.log.info("Directory dir1 on %s created successfully",
+                   self.mounts[0])
+
+        ec_version_before_nonfops = []
+        ec_version_after_nonfops = []
+        # Getting the EC version of the directory
+        for brick in bricks_list:
+            brick_node, brick_path = brick.split(":")
+            target_file = brick_path + "/dir1"
+            dir_attribute = get_extended_attributes_info(brick_node,
+                                                         [target_file])
+            ec_version_before_nonfops.append(dir_attribute
+                                             [target_file]
+                                             ['trusted.ec.version'])
+
+        # chmod of dir1 once
+        cmd = ('chmod 777 %s/dir1'
+               % (self.mounts[0].mountpoint))
+        g.run(self.mounts[0].client_system, cmd)
+
+        # chmod of dir1 twice
+        cmd = ('chmod 777 %s/dir1'
+               % (self.mounts[0].mountpoint))
+        g.run(self.mounts[0].client_system, cmd)
+
+        # Getting the EC version of the directory
+        # After changing mode of the directory
+        for brick in bricks_list:
+            brick_node, brick_path = brick.split(":")
+            target_file = brick_path + "/dir1"
+            dir_attribute = get_extended_attributes_info(brick_node,
+                                                         [target_file])
+            ec_version_after_nonfops.append(dir_attribute
+                                            [target_file]
+                                            ['trusted.ec.version'])
+
+        # Comparing the EC version before and after non data FOP
+        self.assertEqual(ec_version_before_nonfops, ec_version_after_nonfops,
+                         "EC version updated for non data FOP")
+        g.log.info("EC version is same for before and after non data FOP"
+                   "%s", self.volname)


### PR DESCRIPTION
Migrated TC [test_nonfop_ecversion](https://github.com/gluster/glusto-tests/blob/master/tests/functional/disperse/test_nonfop_ecversion.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>