### PR TITLE
[Common]: Fix quorum_type check

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -1293,7 +1293,7 @@ class BrickOps(AbstractOps):
         # offline_bricks_limit: Maximum Number of bricks that can be offline
         # without affecting the cluster
         if is_quorum_applicable:
-            if 'fixed' in quorum_type:
+            if quorum_type and 'fixed' in quorum_type:
                 if quorum_count is None:
                     self.logger.error("Quorum type is 'fixed' for"
                                       " the volume. But Quorum "
@@ -1303,7 +1303,7 @@ class BrickOps(AbstractOps):
                     offline_bricks_limit = (
                         int(replica_count) - int(quorum_count))
 
-            elif 'auto' in quorum_type:
+            elif quorum_type and 'auto' in quorum_type:
                 offline_bricks_limit = int(replica_count) // 2
 
             elif quorum_type is None:

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -1787,7 +1787,7 @@ class VolumeOps(AbstractOps):
 
             # Case2: Replica > 2
             if int(replica_count) > 2:
-                if quorum_type == 'none':
+                if 'none' in quorum_type:
                     (client_quorum_dict['volume_quorum_info']
                         ['quorum_type']) = 'auto'
                 elif quorum_type == 'fixed':


### PR DESCRIPTION
**Description:**
Fixed the quorum_type` value check in the brick_ops. The `quorum_type` will be `none` in case
the replica count is 2 and `none` type is not iterable. Hence, added a sanity check for the `quorum_type`
variable before using it.

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
