### PR TITLE
[Common] Updated use of cleanup_volumes function

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -512,6 +512,12 @@ class VolumeOps(AbstractOps):
             self.logger.error(f"Unable to cleanup the volume {volname}")
             return False
 
+        brick_list = self.get_all_bricks(volname, node)
+        if not brick_list:
+            self.logger.error("Failed to get the brick list")
+            return False
+        self.delete_bricks(brick_list)
+
         self.logger.debug(f"Successfully cleaned the volume: {volname}")
         return True
 

--- a/core/environ.py
+++ b/core/environ.py
@@ -144,6 +144,7 @@ class environ:
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)
+            self.wait_till_all_peers_connected(self.server_list)
             self._check_and_copy_scripts()
             self._check_and_install_arequal_checksum()
             self.redant.logger.info("Environment setup success.")

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -66,6 +66,7 @@ class DParentTest(metaclass=abc.ABCMeta):
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)
+            self.wait_till_all_peers_connected(self.server_list)
 
             # Call setup in case you want to override volume creation,
             # start, mounting in the TC

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -36,9 +36,9 @@ class TestCase(DParentTest):
         6. check for pidof glusterfsd single process should be visible
         """
 
-        redant.delete_cluster(self.server_list)
-
         redant.create_cluster(self.server_list[:3])
+        redant.wait_till_all_peers_connected(self.server_list[:3])
+
         conf_dict = self.vol_type_inf["rep"]
         volname = f"{self.test_name}"
         # Volume Creation

--- a/tests/functional/glusterd/test_change_reserve_limit.py
+++ b/tests/functional/glusterd/test_change_reserve_limit.py
@@ -44,7 +44,7 @@ class TestChangeReservcelimit(NdParentTest):
             self.redant.logger.error(tb)
         super().terminate()
 
-    def set_storage_reserve_value(self, redant, vol_name, storage_res_val):
+    def _set_storage_reserve_value(self, redant, vol_name, storage_res_val):
         """
         Test Case:
         1) Create a distributed-replicated volume and start it.
@@ -125,4 +125,4 @@ class TestChangeReservcelimit(NdParentTest):
 
         # change_reserve_limit_to_higher_value is a seperate test case
         # which is being merged into a single test case
-        self.set_storage_reserve_value(redant, self.volume_name1, "99")
+        self._set_storage_reserve_value(redant, self.volume_name1, "99")

--- a/tests/functional/glusterd/test_concurrent_set.py
+++ b/tests/functional/glusterd/test_concurrent_set.py
@@ -30,7 +30,7 @@ class TestCase(NdParentTest):
 
     def terminate(self):
         try:
-            self.redant.cleanup_volumes(self.server_list, self.volume_name1)
+            self.redant.cleanup_volume(self.server_list, self.volume_name1)
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)

--- a/tests/functional/glusterd/test_create_vol_with_used_bricks.py
+++ b/tests/functional/glusterd/test_create_vol_with_used_bricks.py
@@ -35,8 +35,14 @@ class TestCase(NdParentTest):
                                                       self.mounts)
             if not ret:
                 raise Exception("IO failed on some of the clients")
-            vol_list = [self.volume_name1, self.volname]
-            self.redant.cleanup_volumes(self.server_list, vol_list)
+
+            # Cleanup the remaining volumes
+            curr_vol_list = self.redant.get_volume_list(self.server_list[0])
+            tc_vol_list = [self.volume_name1, self.volname]
+            for volume in tc_vol_list:
+                if volume in curr_vol_list:
+                    self.redant.cleanup_volumes(self.server_list, volume)
+
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)

--- a/tests/functional/glusterd/test_gluster_volume_status_xml_dump.py
+++ b/tests/functional/glusterd/test_gluster_volume_status_xml_dump.py
@@ -34,8 +34,13 @@ class TestCase(NdParentTest):
         destroyed
         """
         try:
-            vol_list = [self.volume_name1, self.volume_name]
-            self.redant.cleanup_volumes(self.server_list, vol_list)
+            # Cleanup the remaining volumes
+            curr_vol_list = self.redant.get_volume_list(self.server_list[0])
+            tc_vol_list = [self.volume_name1, self.volume_name]
+            for volume in tc_vol_list:
+                if volume in curr_vol_list:
+                    self.redant.cleanup_volumes(self.server_list, volume)
+
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -32,6 +32,9 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
+        # Exit if cluster size less than 4
+        # Check server requirements
+        self.redant.check_hardware_requirements(self.server_list, 4)
 
     def terminate(self):
         """
@@ -63,14 +66,9 @@ class TestCase(DParentTest):
         """
         self.vol_exist = False
 
-        # Exit if cluster size less than 4
-        # Check server requirements
-        redant.check_hardware_requirements(self.server_list, 4)
-
         # Peer probe first 3 servers
         redant.create_cluster(self.server_list[:3])
-        redant.wait_for_peers_to_connect(self.server_list[:3],
-                                         self.server_list[0])
+        redant.wait_till_all_peers_connected(self.server_list[:3])
 
         # Create a volume using the first 3 nodes
         conf_dict = self.vol_type_inf[self.volume_type]

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -147,9 +147,3 @@ class TestCase(DParentTest):
 
         # perform the set of volume operations
         self._vol_operations(redant, "test-vol-fqdn")
-
-        # creating the cluster back again
-        ret = redant.create_cluster(self.server_list)
-
-        if not ret:
-            raise Exception("Cluster creation failed")

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -35,7 +35,7 @@ class TestCase(DParentTest):
         terminate function in the DParentTest is called
         """
         try:
-            self.redant.cleanup_volumes(self.server_list, self.volume_name1)
+            self.redant.cleanup_volume(self.server_list, self.volume_name1)
             ret = self.redant.wait_for_io_to_complete(self.list_of_procs,
                                                       self.mnt_list)
             if not ret:

--- a/tests/functional/glusterd/test_quorum_syslog.py
+++ b/tests/functional/glusterd/test_quorum_syslog.py
@@ -50,7 +50,9 @@ class TestCase(DParentTest):
                 raise Exception("Servers are not in peer probed state")
 
             # stopping the volume and Cleaning up the volume
-            self.redant.cleanup_volumes(self.server_list, self.volume_name1)
+            if self.volume_name1:
+                self.redant.cleanup_volume(self.server_list,
+                                           self.volume_name1)
 
         except Exception as error:
             tb = traceback.format_exc()
@@ -73,6 +75,7 @@ class TestCase(DParentTest):
         for both the volumes in /var/log/messages and
         /var/log/glusterfs/glusterd.log
         """
+        self.volume_name1 = ""
 
         if redant.check_os("fedora", nodes=self.server_list):
             self.TEST_RES[0] = None

--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -41,6 +41,7 @@ class TestCase(DParentTest):
         # create a two node cluster
         cluster_nodes = self.server_list[:2]
         redant.create_cluster(cluster_nodes)
+        redant.wait_till_all_peers_connected(cluster_nodes)
 
         # create a distributed volume with single node
         volume_type = 'dist'


### PR DESCRIPTION
## Description:

Updated the usage of the `cleanup_volumes` function within the TCs
Added a peer connection check after forming the cluster, because in the `create_cluster` function
we don't validate the `peer_status ` of the cluster, and as a reason many times the TC fails with the `Peer is not connected` error.

Fixes: #1012 

Signed-off-by: nik-redhat <nladha@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
