### PR TITLE
Use deepcopy() method for copying dict

### DIFF
--- a/tests/functional/afr/heal/test_data_split_brain_resolution.py
+++ b/tests/functional/afr/heal/test_data_split_brain_resolution.py
@@ -33,7 +33,7 @@ class TestCase(DParentTest):
         """
         Override the volume create
         """
-        conf_hash = self.vol_type_inf['rep']
+        conf_hash = self.vol_type_inf['rep'].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/heal/test_data_split_brain_resolution.py
+++ b/tests/functional/afr/heal/test_data_split_brain_resolution.py
@@ -22,7 +22,7 @@ Description:
 """
 
 # disruptive;rep
-
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -33,7 +33,7 @@ class TestCase(DParentTest):
         """
         Override the volume create
         """
-        conf_hash = self.vol_type_inf['rep'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['rep'])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/heal/test_metadata_split_brain_resolution.py
+++ b/tests/functional/afr/heal/test_metadata_split_brain_resolution.py
@@ -33,7 +33,7 @@ class TestCase(DParentTest):
         """
         Override the volume create
         """
-        conf_hash = self.vol_type_inf['rep']
+        conf_hash = self.vol_type_inf['rep'].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/heal/test_metadata_split_brain_resolution.py
+++ b/tests/functional/afr/heal/test_metadata_split_brain_resolution.py
@@ -22,7 +22,7 @@
 """
 
 # disruptive;rep
-
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -33,7 +33,7 @@ class TestCase(DParentTest):
         """
         Override the volume create
         """
-        conf_hash = self.vol_type_inf['rep'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['rep'])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_afr_cli_gfid_splitbrain.py
+++ b/tests/functional/afr/test_afr_cli_gfid_splitbrain.py
@@ -34,7 +34,7 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['rep']
+        conf_hash = self.vol_type_inf['rep'].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_afr_cli_gfid_splitbrain.py
+++ b/tests/functional/afr/test_afr_cli_gfid_splitbrain.py
@@ -22,7 +22,7 @@ Description:
 
 # disruptive;rep
 # TODO: cifs
-
+from copy import deepcopy
 import traceback
 from tests.d_parent_test import DParentTest
 
@@ -34,7 +34,7 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['rep'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['rep'])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_afr_cli_no_splitbrain_resolution.py
+++ b/tests/functional/afr/test_afr_cli_no_splitbrain_resolution.py
@@ -25,7 +25,7 @@ Description:
 
 
 # disruptive;rep
-
+from copy import deepcopy
 import traceback
 from tests.d_parent_test import DParentTest
 
@@ -37,7 +37,7 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['rep'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['rep'])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_afr_cli_no_splitbrain_resolution.py
+++ b/tests/functional/afr/test_afr_cli_no_splitbrain_resolution.py
@@ -37,7 +37,7 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['rep']
+        conf_hash = self.vol_type_inf['rep'].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_afr_dir_entry_creation_with_subvol_down.py
+++ b/tests/functional/afr/test_afr_dir_entry_creation_with_subvol_down.py
@@ -21,6 +21,7 @@
 
 # disruptive;dist-arb,dist-rep
 from time import sleep
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -31,7 +32,7 @@ class TestAfrDirEntryCreationWithSubvolDown(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         conf_hash['dist_count'] = 3
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_afr_dir_entry_creation_with_subvol_down.py
+++ b/tests/functional/afr/test_afr_dir_entry_creation_with_subvol_down.py
@@ -31,7 +31,7 @@ class TestAfrDirEntryCreationWithSubvolDown(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         conf_hash['dist_count'] = 3
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_client_io_threads_on_replicated_volumes.py
+++ b/tests/functional/afr/test_client_io_threads_on_replicated_volumes.py
@@ -20,6 +20,7 @@
 """
 
 # disruptive;dist,rep
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -30,7 +31,7 @@ class TestClientIOThreadsOnReplicatedVolumes(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         if self.volume_type == "dist":
             conf_hash['dist_count'] = 1
 

--- a/tests/functional/afr/test_client_io_threads_on_replicated_volumes.py
+++ b/tests/functional/afr/test_client_io_threads_on_replicated_volumes.py
@@ -30,7 +30,7 @@ class TestClientIOThreadsOnReplicatedVolumes(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         if self.volume_type == "dist":
             conf_hash['dist_count'] = 1
 

--- a/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
@@ -32,7 +32,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         Override the volume create, start and mount in parent_run_test
         """
         self.script_file_path = "/usr/share/redant/script/file_dir_ops.py"
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py
@@ -21,6 +21,7 @@
 
 # disruptive;rep,dist-rep
 # TODO: nfs
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -32,7 +33,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         Override the volume create, start and mount in parent_run_test
         """
         self.script_file_path = "/usr/share/redant/script/file_dir_ops.py"
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_client_side_quorum_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_with_cross2.py
@@ -21,6 +21,7 @@
 
 # disruptive;rep,dist-rep
 # TODO: nfs
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -31,7 +32,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_client_side_quorum_with_cross2.py
+++ b/tests/functional/afr/test_client_side_quorum_with_cross2.py
@@ -31,7 +31,7 @@ class TestClientSideQuorumCross2Tests(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_client_side_quorum_with_multiple_volumes.py
+++ b/tests/functional/afr/test_client_side_quorum_with_multiple_volumes.py
@@ -20,6 +20,7 @@
 """
 
 # disruptive;dist-rep
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -34,7 +35,7 @@ class TestClientSideQuorumTestsMultipleVols(DParentTest):
         self.mounts_list = []
         self.mount_points_and_volnames = {}
         for i in range(1, 5):
-            conf_hash = self.vol_type_inf['dist-rep'].copy()
+            conf_hash = deepcopy(self.vol_type_inf['dist-rep'])
             if i < 3:
                 conf_hash['dist_count'] = 2
             vol_name = f"testvol-{self.volume_type}-{i}"
@@ -50,7 +51,7 @@ class TestClientSideQuorumTestsMultipleVols(DParentTest):
             self.mounts_list.append(mountpoint)
             self.mount_points_and_volnames[vol_name] = mountpoint
 
-        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['dist'])
         vol_name = f"testvol-{self.volume_type}-5"
         self.redant.setup_volume(vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_client_side_quorum_with_multiple_volumes.py
+++ b/tests/functional/afr/test_client_side_quorum_with_multiple_volumes.py
@@ -34,7 +34,7 @@ class TestClientSideQuorumTestsMultipleVols(DParentTest):
         self.mounts_list = []
         self.mount_points_and_volnames = {}
         for i in range(1, 5):
-            conf_hash = self.vol_type_inf['dist-rep']
+            conf_hash = self.vol_type_inf['dist-rep'].copy()
             if i < 3:
                 conf_hash['dist_count'] = 2
             vol_name = f"testvol-{self.volume_type}-{i}"
@@ -50,7 +50,7 @@ class TestClientSideQuorumTestsMultipleVols(DParentTest):
             self.mounts_list.append(mountpoint)
             self.mount_points_and_volnames[vol_name] = mountpoint
 
-        conf_hash = self.vol_type_inf['dist']
+        conf_hash = self.vol_type_inf['dist'].copy()
         vol_name = f"testvol-{self.volume_type}-5"
         self.redant.setup_volume(vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_conservative_merge_of_files_heal_command.py
+++ b/tests/functional/afr/test_conservative_merge_of_files_heal_command.py
@@ -21,6 +21,7 @@
 
 # disruptive;rep
 # TODO: NFS, CIFS
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -31,7 +32,7 @@ class TestVerifySelfHealTriggersHealCommand(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['rep'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['rep'])
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_conservative_merge_of_files_heal_command.py
+++ b/tests/functional/afr/test_conservative_merge_of_files_heal_command.py
@@ -31,7 +31,7 @@ class TestVerifySelfHealTriggersHealCommand(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['rep']
+        conf_hash = self.vol_type_inf['rep'].copy()
         conf_hash['replica_count'] = 2
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_dist_to_repl_automatic_heal_should_be_triggered.py
+++ b/tests/functional/afr/test_dist_to_repl_automatic_heal_should_be_triggered.py
@@ -31,7 +31,7 @@ class TestSelfHeal(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['dist']
+        conf_hash = self.vol_type_inf['dist'].copy()
         conf_hash['dist_count'] = 1
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_dist_to_repl_automatic_heal_should_be_triggered.py
+++ b/tests/functional/afr/test_dist_to_repl_automatic_heal_should_be_triggered.py
@@ -21,6 +21,7 @@
 """
 
 # disruptive;dist
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -31,7 +32,7 @@ class TestSelfHeal(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['dist'])
         conf_hash['dist_count'] = 1
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_manual_heal_full_should_trigger_heal.py
+++ b/tests/functional/afr/test_manual_heal_full_should_trigger_heal.py
@@ -30,7 +30,7 @@ class TestSelfHeal(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['dist']
+        conf_hash = self.vol_type_inf['dist'].copy()
         conf_hash['dist_count'] = 1
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_manual_heal_full_should_trigger_heal.py
+++ b/tests/functional/afr/test_manual_heal_full_should_trigger_heal.py
@@ -20,6 +20,7 @@
 """
 
 # disruptive;dist
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -30,7 +31,7 @@ class TestSelfHeal(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['dist'])
         conf_hash['dist_count'] = 1
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_manual_heal_should_trigger_heal.py
+++ b/tests/functional/afr/test_manual_heal_should_trigger_heal.py
@@ -30,7 +30,7 @@ class TestSelfHeal(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['dist']
+        conf_hash = self.vol_type_inf['dist'].copy()
         conf_hash['dist_count'] = 1
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_manual_heal_should_trigger_heal.py
+++ b/tests/functional/afr/test_manual_heal_should_trigger_heal.py
@@ -20,6 +20,7 @@
 """
 
 # disruptive;dist
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -30,7 +31,7 @@ class TestSelfHeal(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['dist'])
         conf_hash['dist_count'] = 1
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_repl_heal_with_io.py
+++ b/tests/functional/afr/test_repl_heal_with_io.py
@@ -20,6 +20,7 @@
 """
 
 # disruptive;arb,dist-arb,rep,dist-rep
+from copy import deepcopy
 from random import choice
 from time import sleep, time
 import traceback
@@ -33,7 +34,7 @@ class TestHealWithIO(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         if self.volume_type.find("dist") >= 0:
             conf_hash['dist_count'] = 6
 
@@ -276,7 +277,7 @@ class TestHealWithIO(DParentTest):
         redant.logger.info("Test heal info with IO and brick down completed")
 
         # Create, start and mount volume for rest of the tests
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         self.vol_name = f"{self.vol_name}-1"
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/afr/test_repl_heal_with_io.py
+++ b/tests/functional/afr/test_repl_heal_with_io.py
@@ -33,7 +33,7 @@ class TestHealWithIO(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         if self.volume_type.find("dist") >= 0:
             conf_hash['dist_count'] = 6
 
@@ -276,7 +276,7 @@ class TestHealWithIO(DParentTest):
         redant.logger.info("Test heal info with IO and brick down completed")
 
         # Create, start and mount volume for rest of the tests
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         self.vol_name = f"{self.vol_name}-1"
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/glusterd/test_add_brick.py
+++ b/tests/functional/glusterd/test_add_brick.py
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 Description:
 This test case tests various add brick scenarios
 """
+from copy import deepcopy
 import random
 from tests.d_parent_test import DParentTest
 
@@ -37,7 +38,7 @@ class TestCase(DParentTest):
            part of the cluster.
         """
         # form bricks list to test add brick functionality
-        rep_count = self.vol_type_inf['rep'].copy()
+        rep_count = deepcopy(self.vol_type_inf['rep'])
         rep_count = rep_count['replica_count']
         num_of_bricks = 4 * rep_count
 

--- a/tests/functional/glusterd/test_add_brick.py
+++ b/tests/functional/glusterd/test_add_brick.py
@@ -37,7 +37,7 @@ class TestCase(DParentTest):
            part of the cluster.
         """
         # form bricks list to test add brick functionality
-        rep_count = self.vol_type_inf['rep']
+        rep_count = self.vol_type_inf['rep'].copy()
         rep_count = rep_count['replica_count']
         num_of_bricks = 4 * rep_count
 

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -20,6 +20,7 @@
     brick on a new node and checking volume status.
 """
 
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 
@@ -41,7 +42,7 @@ class TestCase(DParentTest):
         # Create a distributed volume on Node1
         self.volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-        conf_dict = self.vol_type_inf[self.volume_type1].copy()
+        conf_dict = deepcopy(self.vol_type_inf[self.volume_type1])
         conf_dict['dist_count'] = 1
         redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,
                             [self.server_list[0]], self.brick_roots, True)

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -41,7 +41,7 @@ class TestCase(DParentTest):
         # Create a distributed volume on Node1
         self.volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-        conf_dict = self.vol_type_inf[self.volume_type1]
+        conf_dict = self.vol_type_inf[self.volume_type1].copy()
         conf_dict['dist_count'] = 1
         redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,
                             [self.server_list[0]], self.brick_roots, True)

--- a/tests/functional/glusterd/test_create_vol_with_used_bricks.py
+++ b/tests/functional/glusterd/test_create_vol_with_used_bricks.py
@@ -43,6 +43,9 @@ class TestCase(NdParentTest):
                 if volume in curr_vol_list:
                     self.redant.cleanup_volumes(self.server_list, volume)
 
+            # Delete the bricks created in the TC
+            self.redant.delete_bricks(self.bricks_list)
+
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)
@@ -111,9 +114,9 @@ class TestCase(NdParentTest):
                               mountpoint,
                               self.client_list[0])
         # get the list of all bricks
-        bricks_list = redant.get_all_bricks(self.volume_name1,
-                                            self.server_list[0])
-        if bricks_list is None:
+        self.bricks_list = redant.get_all_bricks(self.volume_name1,
+                                                 self.server_list[0])
+        if self.bricks_list is None:
             raise Exception("Failed to get the list of all the bricks")
 
         # Stop the volume
@@ -124,7 +127,7 @@ class TestCase(NdParentTest):
 
         self.volname = "test_create_vol_used_bricks"
 
-        brick_cmd = " ".join(bricks_list[0:6])
+        brick_cmd = " ".join(self.bricks_list[0:6])
 
         cmd = (f"gluster volume create {self.volname}"
                f" replica 3 {brick_cmd} --mode=script")
@@ -140,7 +143,7 @@ class TestCase(NdParentTest):
         # Checking failed message of volume creation
         err = ret['error_msg']
         msg = ' '.join(['volume create: test_create_vol_used_bricks: failed:',
-                        bricks_list[0].split(':')[1],
+                        self.bricks_list[0].split(':')[1],
                         'is already part of a volume'])
         if msg not in err:
             raise Exception("Incorrect error message for volume creation "

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -50,19 +50,19 @@ class TestCase(DParentTest):
         # Create a distributed volume on Node1
         volume_type1 = 'dist'
         volume_name1 = f"{self.test_name}-{volume_type1}-1"
-        self.vol_type_inf[volume_type1]['dist-count'] = 1
-        vol_params_dict = self.vol_type_inf[volume_type1]
+        conf_hash = self.vol_type_inf[volume_type1].copy()
+        conf_hash['dist-count'] = 1
         ret = redant.volume_create(volume_name1, self.server_list[0],
-                                   vol_params_dict, self.server_list[0],
+                                   conf_hash, self.server_list[0],
                                    self.brick_roots, True)
 
         # Create a replicate volume on Node2 without force should fail
         volume_type2 = 'rep'
         volume_name2 = f"{self.test_name}-{volume_type2}-2"
-        self.vol_type_inf[volume_type2]['replica_count'] = 2
-        vol_params_dict = self.vol_type_inf[volume_type2]
+        conf_hash = self.vol_type_inf[volume_type2].copy()
+        conf_hash['replica_count'] = 2
         ret = redant.volume_create(volume_name2, self.server_list[1],
-                                   vol_params_dict, self.server_list[1],
+                                   conf_hash, self.server_list[1],
                                    self.brick_roots, excep=False)
         if ret['error_code'] == 0:
             raise Exception("Unexpected: Successfully created "
@@ -72,10 +72,10 @@ class TestCase(DParentTest):
         # Create a replica volume on Node2 with force should succeed
         volume_type3 = 'rep'
         volume_name3 = f"{self.test_name}-{volume_type3}-3"
-        self.vol_type_inf[volume_type3]['replica-count'] = 3
-        vol_params_dict = self.vol_type_inf[volume_type3]
+        conf_hash = self.vol_type_inf[volume_type3].copy()
+        conf_hash['replica_count'] = 3
         ret = redant.volume_create(volume_name3, self.server_list[1],
-                                   vol_params_dict, self.server_list[1],
+                                   conf_hash, self.server_list[1],
                                    self.brick_roots, True)
 
         # Perform peer probe from N1 to N2
@@ -116,10 +116,10 @@ class TestCase(DParentTest):
         # Create a replica volume on N1 and N2 with force
         volume_type4 = 'rep'
         volume_name4 = f"{self.test_name}-{volume_type4}-4"
-        self.vol_type_inf[volume_type4]['replica-count'] = 2
-        vol_params_dict = self.vol_type_inf[volume_type4]
+        conf_hash = self.vol_type_inf[volume_type4].copy()
+        conf_hash['replica_count'] = 2
         ret = redant.volume_create(volume_name4, self.server_list[0],
-                                   vol_params_dict, self.server_list[0:2],
+                                   conf_hash, self.server_list[0:2],
                                    self.brick_roots, True)
 
         # Perform peer probe from N3 to N1 should fail
@@ -148,10 +148,10 @@ class TestCase(DParentTest):
         # Create a replica volume on N1, N2 and N3 with force
         volume_type5 = 'rep'
         volume_name5 = f"{self.test_name}-{volume_type5}-5"
-        self.vol_type_inf[volume_type5]['replica-count'] = 3
-        vol_params_dict = self.vol_type_inf[volume_type5]
+        conf_hash = self.vol_type_inf[volume_type5].copy()
+        conf_hash['replica_count'] = 3
         ret = redant.volume_create(volume_name5, self.server_list[0],
-                                   vol_params_dict, self.server_list,
+                                   conf_hash, self.server_list,
                                    self.brick_roots, True)
 
         ret = redant.volume_start(volume_name5, self.server_list[2], True)

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -19,6 +19,7 @@
   Validating various cases of peer probe between nodes with
   volume creation on different nodes.
 """
+from copy import deepcopy
 from time import sleep
 from tests.d_parent_test import DParentTest
 
@@ -50,7 +51,7 @@ class TestCase(DParentTest):
         # Create a distributed volume on Node1
         volume_type1 = 'dist'
         volume_name1 = f"{self.test_name}-{volume_type1}-1"
-        conf_hash = self.vol_type_inf[volume_type1].copy()
+        conf_hash = deepcopy(self.vol_type_inf[volume_type1])
         conf_hash['dist-count'] = 1
         ret = redant.volume_create(volume_name1, self.server_list[0],
                                    conf_hash, self.server_list[0],
@@ -59,7 +60,7 @@ class TestCase(DParentTest):
         # Create a replicate volume on Node2 without force should fail
         volume_type2 = 'rep'
         volume_name2 = f"{self.test_name}-{volume_type2}-2"
-        conf_hash = self.vol_type_inf[volume_type2].copy()
+        conf_hash = deepcopy(self.vol_type_inf[volume_type2])
         conf_hash['replica_count'] = 2
         ret = redant.volume_create(volume_name2, self.server_list[1],
                                    conf_hash, self.server_list[1],
@@ -72,7 +73,7 @@ class TestCase(DParentTest):
         # Create a replica volume on Node2 with force should succeed
         volume_type3 = 'rep'
         volume_name3 = f"{self.test_name}-{volume_type3}-3"
-        conf_hash = self.vol_type_inf[volume_type3].copy()
+        conf_hash = deepcopy(self.vol_type_inf[volume_type3])
         conf_hash['replica_count'] = 3
         ret = redant.volume_create(volume_name3, self.server_list[1],
                                    conf_hash, self.server_list[1],
@@ -116,7 +117,7 @@ class TestCase(DParentTest):
         # Create a replica volume on N1 and N2 with force
         volume_type4 = 'rep'
         volume_name4 = f"{self.test_name}-{volume_type4}-4"
-        conf_hash = self.vol_type_inf[volume_type4].copy()
+        conf_hash = deepcopy(self.vol_type_inf[volume_type4])
         conf_hash['replica_count'] = 2
         ret = redant.volume_create(volume_name4, self.server_list[0],
                                    conf_hash, self.server_list[0:2],
@@ -148,7 +149,7 @@ class TestCase(DParentTest):
         # Create a replica volume on N1, N2 and N3 with force
         volume_type5 = 'rep'
         volume_name5 = f"{self.test_name}-{volume_type5}-5"
-        conf_hash = self.vol_type_inf[volume_type5].copy()
+        conf_hash = deepcopy(self.vol_type_inf[volume_type5])
         conf_hash['replica_count'] = 3
         ret = redant.volume_create(volume_name5, self.server_list[0],
                                    conf_hash, self.server_list,

--- a/tests/functional/glusterd/test_peer_status.py
+++ b/tests/functional/glusterd/test_peer_status.py
@@ -73,11 +73,11 @@ class TestPeerStatus(DParentTest):
                             f"{self.server_list[1]}")
 
         # create a distributed volume with 2 bricks
-        self.vol_type_inf['dist']['dist_count'] = 2
+        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash['dist_count'] = 2
         redant.setup_volume(self.vol_name, self.server_list[0],
-                            self.vol_type_inf['dist'],
-                            self.server_list[0:2], self.brick_roots,
-                            True)
+                            conf_hash, self.server_list[0:2],
+                            self.brick_roots, force=True)
 
         # peer probe to a new node, N3
         redant.peer_probe(self.server_list[2], self.server_list[0])

--- a/tests/functional/glusterd/test_peer_status.py
+++ b/tests/functional/glusterd/test_peer_status.py
@@ -20,6 +20,7 @@
   and checking if the brick is correctly added.
 """
 
+from copy import deepcopy
 import socket
 from tests.d_parent_test import DParentTest
 
@@ -73,7 +74,7 @@ class TestPeerStatus(DParentTest):
                             f"{self.server_list[1]}")
 
         # create a distributed volume with 2 bricks
-        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['dist'])
         conf_hash['dist_count'] = 2
         redant.setup_volume(self.vol_name, self.server_list[0],
                             conf_hash, self.server_list[0:2],

--- a/tests/functional/glusterd/test_rebalance_hang.py
+++ b/tests/functional/glusterd/test_rebalance_hang.py
@@ -19,6 +19,7 @@ Description: Test case to check if the rebalance hangs after a node
 is stopped.
 """
 
+from copy import deepcopy
 import traceback
 from tests.d_parent_test import DParentTest
 
@@ -65,7 +66,7 @@ class TestCase(DParentTest):
         redant.create_cluster(self.server_list[:2])
         redant.wait_till_all_peers_connected(self.server_list[:2])
 
-        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash = deepcopy(self.vol_type_inf['dist'])
         conf_hash['dist-count'] = 2
         redant.volume_create(self.vol_name, self.server_list[0],
                              conf_hash, self.server_list[:2],

--- a/tests/functional/glusterd/test_rebalance_hang.py
+++ b/tests/functional/glusterd/test_rebalance_hang.py
@@ -65,10 +65,10 @@ class TestCase(DParentTest):
         redant.create_cluster(self.server_list[:2])
         redant.wait_till_all_peers_connected(self.server_list[:2])
 
-        self.vol_type_inf['dist']['dist-count'] = 2
-        vol_params_dict = self.vol_type_inf['dist']
+        conf_hash = self.vol_type_inf['dist'].copy()
+        conf_hash['dist-count'] = 2
         redant.volume_create(self.vol_name, self.server_list[0],
-                             vol_params_dict, self.server_list[:2],
+                             conf_hash, self.server_list[:2],
                              self.brick_roots, True)
 
         redant.volume_start(self.vol_name, self.server_list[0], True)

--- a/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
+++ b/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
@@ -51,7 +51,7 @@ class TestCase(DParentTest):
         # Create Volume
         self.volume_type = "dist-rep"
         self.vol_name = (f"{self.test_name}-{self.volume_type}")
-        conf_hash = self.vol_type_inf[self.volume_type]
+        conf_hash = self.vol_type_inf[self.volume_type].copy()
         redant.volume_create(self.vol_name, self.server_list[0], conf_hash,
                              self.server_list, self.brick_roots)
 

--- a/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
+++ b/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
@@ -19,6 +19,7 @@
     Test replace brick when quorum not met
 """
 
+from copy import deepcopy
 import random
 from tests.d_parent_test import DParentTest
 
@@ -51,7 +52,7 @@ class TestCase(DParentTest):
         # Create Volume
         self.volume_type = "dist-rep"
         self.vol_name = (f"{self.test_name}-{self.volume_type}")
-        conf_hash = self.vol_type_inf[self.volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
         redant.volume_create(self.vol_name, self.server_list[0], conf_hash,
                              self.server_list, self.brick_roots)
 

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -93,7 +93,7 @@ class TestCase(DParentTest):
         # creating a volume with non existing brick path should fail
         self.volume_type3 = 'dist'
         self.volume_name3 = f"{self.test_name}-{self.volume_type3}-3"
-        conf_dict = self.vol_type_inf[self.volume_type2]
+        conf_dict = self.vol_type_inf[self.volume_type3]
         brick_dict, brick_cmd = redant.form_brick_cmd(self.server_list,
                                                       self.brick_roots,
                                                       self.volume_name3, 2)

--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -45,10 +45,11 @@ class TestCase(DParentTest):
 
         # create a distributed volume with single node
         volume_type = 'dist'
-        self.vol_type_inf[volume_type]['dist_count'] = 1
+        conf_hash = self.vol_type_inf[volume_type].copy()
+        conf_hash['dist_count'] = 1
         redant.volume_create(self.vol_name, self.server_list[0],
-                             self.vol_type_inf[volume_type],
-                             self.server_list, self.brick_roots, True)
+                             conf_hash, self.server_list,
+                             self.brick_roots, True)
 
         # Get volume status
         cmd = f'gluster vol status {self.vol_name}'

--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -19,7 +19,7 @@ Description:
     Test volume status before and after volume start.
 """
 
-
+from copy import deepcopy
 from tests.d_parent_test import DParentTest
 
 # disruptive;
@@ -45,7 +45,7 @@ class TestCase(DParentTest):
 
         # create a distributed volume with single node
         volume_type = 'dist'
-        conf_hash = self.vol_type_inf[volume_type].copy()
+        conf_hash = deepcopy(self.vol_type_inf[volume_type])
         conf_hash['dist_count'] = 1
         redant.volume_create(self.vol_name, self.server_list[0],
                              conf_hash, self.server_list,


### PR DESCRIPTION
## Description:

In python, when we copy a dictionary it creates a new reference to the old dictionary, and thereby if we update the values in
the new (reference) dictionary, then the old one is also affected. The same has been the case in Redant for the `volume_config` that is being used while creating volumes.
The value of the `self.vol_type_inf` dictionary was copied using the `=` operator and then the contents of the new reference/copy were updated as a result the actual dict was also getting updated and caused spurious failures in the CI to run.

**Fix:**
To overcome, this issue it is recommended to use the  `deepcopy()` method in python to copy such dicts, lists so that instead of a new reference, a completely new object is created from the original reference.

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
