### PR TITLE
Fix: Updated object name

### DIFF
--- a/core/environ.py
+++ b/core/environ.py
@@ -146,7 +146,7 @@ class environ:
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)
-            self.wait_till_all_peers_connected(self.server_list)
+            self.redant.wait_till_all_peers_connected(self.server_list)
             self._check_and_copy_scripts()
             self._check_and_install_arequal_checksum()
             self.redant.logger.info("Environment setup success.")

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -66,7 +66,7 @@ class DParentTest(metaclass=abc.ABCMeta):
         try:
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)
-            self.wait_till_all_peers_connected(self.server_list)
+            self.redant.wait_till_all_peers_connected(self.server_list)
 
             # Call setup in case you want to override volume creation,
             # start, mounting in the TC


### PR DESCRIPTION
**Description:**

Missed `redant` object while calling ops from parent_test and environ.

Signed-off-by: nik-redhat <nladha@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
