### PR TITLE
[Core] Fix handling of wrong path for a TC

### DIFF
--- a/core/test_list_builder.py
+++ b/core/test_list_builder.py
@@ -56,19 +56,19 @@ class TestListBuilder:
             of the complete suite.
         Returns:
         """
+        def path_error_handler(exception_instance):
+            raise FileNotFoundError
+
         global valid_vol_types
         # Obtaining list of paths to the TCs under given directory.
         if not single_tc:
-            try:
-                for root, _, files in os.walk(path):
-                    for tfile in files:
-                        if tfile.endswith(".py") and tfile.startswith("test"):
-                            test_case_path = os.path.join(root, tfile)
-                            if test_case_path not in excluded_tests:
-                                cls.tests_path_list.append(test_case_path)
+            for root, _, files in os.walk(path, onerror=path_error_handler):
+                for tfile in files:
+                    if tfile.endswith(".py") and tfile.startswith("test"):
+                        test_case_path = os.path.join(root, tfile)
+                        if test_case_path not in excluded_tests:
+                            cls.tests_path_list.append(test_case_path)
 
-            except Exception as e:
-                print(e)
         elif path not in excluded_tests:
             cls.tests_path_list.append(path)
 


### PR DESCRIPTION
## Description:

If a path for a single TC was provided which didn't start off with `test` then the framework is erroring out as:
`Test Case in exclude list`, which is wrong.  Rather it should error out as `FileNotFoundError`.

**Fix:**
The `os.walk` ignores `listdir()` errors by default and hence if we get a nonexistent path, it doesn't throw any error or exception.
But, it provided an arg `onerror` to check for such exceptions and abort traversal in case of the wrong path.

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
