### PR TITLE
Migrated TC test_uss_snap_activate_deactivate

### DIFF
--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -108,7 +108,7 @@ class TestCase(DParentTest):
             redant.snap_activate(snap_name, self.server_list[0])
 
         # list activated snapshots directory under .snaps
-        if not redant.view_snap_from_mount(self.mounts, snap_list):
+        if not redant.view_snaps_from_mount(self.mounts, snap_list):
             raise Exception("Snap in .snaps doesn't match snap list provided")
 
         # Deactivate the second snapshot
@@ -123,5 +123,5 @@ class TestCase(DParentTest):
         redant.snap_activate(snap_list[1], self.server_list[0])
 
         # list activated snapshots directory under .snaps
-        if not redant.view_snap_from_mount(self.mounts, snap_list):
+        if not redant.view_snaps_from_mount(self.mounts, snap_list):
             raise Exception("Snap in .snaps doesn't match snap list provided")

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -49,11 +49,9 @@ class SnapUssActiveD(GlusterBaseClass):
         # Upload io scripts for running IO on mounts
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                   "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, script_local_path)
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts "
                                  "to clients ")

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -100,7 +100,7 @@ class SnapUssActiveD(GlusterBaseClass):
         * Perform I/O on mounts
         * Create 2 snapshots snapy1 & snapy2
         * Validate snap created
-        * Enbale USS
+        * Enable USS
         * Validate USS is enabled
         * Validate snapd is running
         * Activate snapy1 & snapy2

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -23,8 +23,7 @@ Description:
 
 from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.gluster_base_class import runs_on
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.io.utils import (validate_io_procs,
                                  view_snaps_from_mount)
 from glustolibs.gluster.snap_ops import (snap_create, snap_delete_all,
@@ -137,11 +136,11 @@ class SnapUssActiveD(GlusterBaseClass):
         self.io_validation_complete = False
 
         # Validate IO
-        self.assertTrue(
-            validate_io_procs(self.all_mounts_procs, self.mounts),
-            "IO failed on some of the clients"
-        )
+        g.log.info("Wait for IO to complete and validate IO ...")
+        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
+        self.assertTrue(ret, "IO failed on some of the clients")
         self.io_validation_complete = True
+        g.log.info("I/O successful on clients")
 
         # Enable USS
         g.log.info("Enable USS on volume")
@@ -166,7 +165,7 @@ class SnapUssActiveD(GlusterBaseClass):
 
         # Create 2 snapshot
         g.log.info("Creating 2 snapshots for volume %s", self.volname)
-        for i in range(0, 2):
+        for i in range(1, 3):
             ret, _, _ = snap_create(self.mnode, self.volname, "snapy%s" % i)
             self.assertEqual(ret, 0, ("Failed to create snapshot for %s"
                                       % self.volname))
@@ -181,7 +180,7 @@ class SnapUssActiveD(GlusterBaseClass):
 
         # Activate snapshot snapy1 & snapy2
         g.log.info("Activating snapshot snapy1 & snapy2")
-        for i in range(0, 2):
+        for i in range(1, 3):
             ret, _, _ = snap_activate(self.mnode, "snapy%s" % i)
             self.assertEqual(ret, 0, "Failed to activate snapshot snapy%s" % i)
         g.log.info("Both snapshots activated successfully")
@@ -211,7 +210,7 @@ class SnapUssActiveD(GlusterBaseClass):
         ret = view_snaps_from_mount(self.mounts, "snapy2")
         self.assertFalse(ret, " UnExpected : Still able to View snapy2"
                          " from mount ")
-        g.log.info("Successfully varified deactivated snapshot "
+        g.log.info("Successfully verified deactivated snapshot "
                    "snapy2 is not listed")
 
         # Activate snapshot snapy2

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -21,7 +21,10 @@ Description:
     snap should not.
 """
 
+import sys
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.io.utils import (validate_io_procs,
@@ -42,7 +45,7 @@ class SnapUssActiveD(GlusterBaseClass):
 
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         # Upload io scripts for running IO on mounts
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
@@ -59,7 +62,7 @@ class SnapUssActiveD(GlusterBaseClass):
     def setUp(self):
 
         # SettingUp and Mounting the volume
-        GlusterBaseClass.setUpClass.im_func(self)
+        self.get_super_method(self, 'setUp')()
         g.log.info("Starting to SetUp Volume and mount volume")
         ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
         if not ret:
@@ -121,14 +124,14 @@ class SnapUssActiveD(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
-                   "--num-of-files 2 %s" % (self.script_upload_path,
-                                            self.counter,
-                                            mount_obj.mountpoint))
+                   "--num-of-files 2 %s" % (
+                       sys.version_info.major, self.script_upload_path,
+                       self.counter, mount_obj.mountpoint))
 
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -137,11 +137,11 @@ class SnapUssActiveD(GlusterBaseClass):
         self.io_validation_complete = False
 
         # Validate IO
-        g.log.info("Wait for IO to complete and validate IO ...")
-        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
-        self.assertTrue(ret, "IO failed on some of the clients")
+        self.assertTrue(
+            validate_io_procs(self.all_mounts_procs, self.mounts),
+            "IO failed on some of the clients"
+        )
         self.io_validation_complete = True
-        g.log.info("I/O successful on clients")
 
         # Enable USS
         g.log.info("Enable USS on volume")

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,6 @@ Description:
     snap should not.
 """
 
-import sys
 
 from glusto.core import Glusto as g
 
@@ -122,13 +121,13 @@ class SnapUssActiveD(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
                    "--num-of-files 2 %s" % (
-                       sys.version_info.major, self.script_upload_path,
+                       self.script_upload_path,
                        self.counter, mount_obj.mountpoint))
 
             proc = g.run_async(mount_obj.client_system, cmd,

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -115,7 +115,7 @@ class TestCase(DParentTest):
         redant.snap_deactivate(snap_list[1], self.server_list[0])
 
         # validate the given snap is absent in mountpoint
-        if redant.view_snaps_from_mount(self.mounts, snap_list[1], False):
+        if redant.view_snaps_from_mount(self.mounts, snap_list[1]):
             raise Exception(f"Snap {snap_list[1]} shouldn't be present under"
                             ".snaps dir")
 

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -1,0 +1,235 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+    This test case will validate USS functionality.
+    Activated snaps should get listed in .snap directory while deactivated
+    snap should not.
+"""
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.gluster_base_class import runs_on
+from glustolibs.io.utils import (validate_io_procs,
+                                 view_snaps_from_mount)
+from glustolibs.gluster.snap_ops import (snap_create, snap_delete_all,
+                                         get_snap_list, snap_activate,
+                                         snap_deactivate)
+from glustolibs.gluster.uss_ops import (enable_uss, is_uss_enabled,
+                                        is_snapd_running, uss_list_snaps,
+                                        disable_uss)
+from glustolibs.misc.misc_libs import upload_scripts
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed', 'distributed-dispersed'],
+          ['glusterfs', 'nfs', 'cifs']])
+class SnapUssActiveD(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+        # Upload io scripts for running IO on mounts
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", cls.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts "
+                                 "to clients ")
+        g.log.info("Successfully uploaded IO scripts to clients %s")
+
+    def setUp(self):
+
+        # SettingUp and Mounting the volume
+        GlusterBaseClass.setUpClass.im_func(self)
+        g.log.info("Starting to SetUp Volume and mount volume")
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume %s" % self.volname)
+        g.log.info("Volume %s has been setup successfully", self.volname)
+
+    def tearDown(self):
+
+        # Deleting all snapshot
+        g.log.info("Deleting all snapshots created")
+        ret, _, _ = snap_delete_all(self.mnode)
+        if ret != 0:
+            raise ExecutionError("Snapshot Delete Failed")
+        g.log.info("Successfully deleted all snapshots")
+
+        # Disable uss for volume
+        g.log.info("Disabling uss for volume")
+        ret, _, _ = disable_uss(self.mnode, self.volname)
+        if ret != 0:
+            raise ExecutionError("Failed to disable uss")
+        g.log.info("Successfully disabled uss for volume"
+                   "%s", self.volname)
+
+        # Unmount and cleanup original volume
+        g.log.info("Starting to Unmount and Cleanup Volume")
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to umount and cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
+
+    def test_uss_snap_active_deactive(self):
+
+        # pylint: disable=too-many-statements
+        """
+        Steps:
+        * Create volume
+        * Mount volume
+        * Perform I/O on mounts
+        * Create 2 snapshots snapy1 & snapy2
+        * Validate snap created
+        * Enbale USS
+        * Validate USS is enabled
+        * Validate snapd is running
+        * Activate snapy1 & snapy2
+        * List snaps under .snap directory
+          -- snap1 and snap2 should be listed under .snaps
+        * Deactivate snapy2
+        * List snaps under .snap directory
+          -- snapy2 is not listed as it is deactivated
+        * Activate snapy2
+        * List snaps under .snap directory
+          -- snap1 and snap2 should be listed under .snaps
+        """
+
+        # Perform I/O
+        g.log.info("Starting IO on all mounts...")
+        self.counter = 1
+        self.all_mounts_procs = []
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dirname-start-num %d "
+                   "--dir-depth 2 "
+                   "--dir-length 2 "
+                   "--max-num-of-dirs 2 "
+                   "--num-of-files 2 %s" % (self.script_upload_path,
+                                            self.counter,
+                                            mount_obj.mountpoint))
+
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+        self.io_validation_complete = False
+
+        # Validate IO
+        g.log.info("Wait for IO to complete and validate IO ...")
+        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
+        self.assertTrue(ret, "IO failed on some of the clients")
+        self.io_validation_complete = True
+        g.log.info("I/O successful on clients")
+
+        # Enable USS
+        g.log.info("Enable USS on volume")
+        ret, _, _ = enable_uss(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to enable USS on volume")
+        g.log.info("Successfully enabled USS on volume")
+
+        # Validate USS is enabled
+        g.log.info("Validating USS is enabled")
+        ret = is_uss_enabled(self.mnode, self.volname)
+        self.assertTrue(ret, "USS is disabled on volume "
+                        "%s" % self.volname)
+        g.log.info("USS enabled on volume %s", self.volname)
+
+        # Validate snapd running
+        for server in self.servers:
+            g.log.info("Validating snapd daemon on:%s", server)
+            ret = is_snapd_running(server, self.volname)
+            self.assertTrue(ret, "Snapd is Not running on "
+                            "%s" % server)
+            g.log.info("Snapd Running on node: %s", server)
+
+        # Create 2 snapshot
+        g.log.info("Creating 2 snapshots for volume %s", self.volname)
+        for i in range(0, 2):
+            ret, _, _ = snap_create(self.mnode, self.volname, "snapy%s" % i)
+            self.assertEqual(ret, 0, ("Failed to create snapshot for %s"
+                                      % self.volname))
+            g.log.info("Snapshot %s created successfully for volume  %s",
+                       "snapy%s" % i, self.volname)
+
+        # Check for no of snaps using snap_list it should be 2 now
+        snap_list = get_snap_list(self.mnode)
+        self.assertEqual(2, len(snap_list), "No of snaps not consistent "
+                         "for volume %s" % self.volname)
+        g.log.info("Successfully validated number of snaps.")
+
+        # Activate snapshot snapy1 & snapy2
+        g.log.info("Activating snapshot snapy1 & snapy2")
+        for i in range(0, 2):
+            ret, _, _ = snap_activate(self.mnode, "snapy%s" % i)
+            self.assertEqual(ret, 0, "Failed to activate snapshot snapy%s" % i)
+        g.log.info("Both snapshots activated successfully")
+
+        # list activated snapshots directory under .snaps
+        g.log.info("Listing activated snapshots under .snaps")
+        for mount_obj in self.mounts:
+            ret, out, _ = uss_list_snaps(mount_obj.client_system,
+                                         mount_obj.mountpoint)
+            self.assertEqual(ret, 0, "Directory Listing Failed for"
+                             " Activated Snapshot")
+            validate_dir = out.split('\n')
+            self.assertIn("snapy1", validate_dir, "Failed to "
+                          "validate snapy1 under .snaps directory")
+            g.log.info("Activated Snapshot snapy1 listed Successfully")
+            self.assertIn("snapy2", validate_dir, "Successfully listed"
+                          " snapy2 under.snaps directory")
+            g.log.info("Expected: De-activated Snapshot not listed")
+
+        # Deactivate snapshot snapy2
+        g.log.info("Deactivating snapshot snapy2")
+        ret, _, _ = snap_deactivate(self.mnode, "snapy2")
+        self.assertEqual(ret, 0, "Failed to deactivate snapshot snapy2")
+        g.log.info("Successfully deactivated snapshot snapy2")
+
+        # validate snapy2 should not present in mountpoint
+        ret = view_snaps_from_mount(self.mounts, "snapy2")
+        self.assertFalse(ret, " UnExpected : Still able to View snapy2"
+                         " from mount ")
+        g.log.info("Successfully varified deactivated snapshot "
+                   "snapy2 is not listed")
+
+        # Activate snapshot snapy2
+        ret, _, _ = snap_activate(self.mnode, "snapy2")
+        self.assertEqual(ret, 0, "Failed to activate Snapshot snapy2")
+        g.log.info("Snapshot snapy2 activated successfully")
+
+        # list activated snapshots directory under .snaps
+        g.log.info("Listing activated snapshots under .snaps")
+        for mount_obj in self.mounts:
+            ret, out, _ = uss_list_snaps(mount_obj.client_system,
+                                         mount_obj.mountpoint)
+            self.assertEqual(ret, 0, "Directory Listing Failed for"
+                             " Activated Snapshot")
+            validate_dir = out.split('\n')
+            self.assertIn("snapy1", validate_dir, "Failed to "
+                          "validate snapy%s under .snaps directory")
+            g.log.info("Activated Snapshot listed Successfully")
+            self.assertIn("snapy2", validate_dir, "Successfully listed"
+                          "snapy2 under .snaps directory")
+            g.log.info("Expected: De-activated Snapshot not listed")

--- a/tests/functional/snapshot/test_uss_snap_active_deactive.py
+++ b/tests/functional/snapshot/test_uss_snap_active_deactive.py
@@ -1,234 +1,127 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-Description:
+  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
     This test case will validate USS functionality.
     Activated snaps should get listed in .snap directory while deactivated
     snap should not.
 """
 
-
-from glusto.core import Glusto as g
-
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.io.utils import (validate_io_procs,
-                                 view_snaps_from_mount)
-from glustolibs.gluster.snap_ops import (snap_create, snap_delete_all,
-                                         get_snap_list, snap_activate,
-                                         snap_deactivate)
-from glustolibs.gluster.uss_ops import (enable_uss, is_uss_enabled,
-                                        is_snapd_running, uss_list_snaps,
-                                        disable_uss)
-from glustolibs.misc.misc_libs import upload_scripts
+# disruptive;rep,dist,disp,dist-rep,dist-disp
+import traceback
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['replicated', 'distributed-replicated', 'dispersed',
-           'distributed', 'distributed-dispersed'],
-          ['glusterfs', 'nfs', 'cifs']])
-class SnapUssActiveD(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-        # Upload io scripts for running IO on mounts
-        g.log.info("Upload io scripts to clients %s for running IO on "
-                   "mounts", cls.clients)
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts "
-                                 "to clients ")
-        g.log.info("Successfully uploaded IO scripts to clients %s")
+    def terminate(self):
+        try:
+            ret = self.redant.wait_for_io_to_complete(self.all_mounts_procs,
+                                                      self.mounts)
+            if not ret:
+                raise Exception("IO failed on some of the clients")
+        except Exception as e:
+            tb = traceback.format_exc()
+            self.redant.logger.error(e)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-    def setUp(self):
+    def run_test(self, redant):
 
-        # SettingUp and Mounting the volume
-        self.get_super_method(self, 'setUp')()
-        g.log.info("Starting to SetUp Volume and mount volume")
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to setup volume %s" % self.volname)
-        g.log.info("Volume %s has been setup successfully", self.volname)
-
-    def tearDown(self):
-
-        # Deleting all snapshot
-        g.log.info("Deleting all snapshots created")
-        ret, _, _ = snap_delete_all(self.mnode)
-        if ret != 0:
-            raise ExecutionError("Snapshot Delete Failed")
-        g.log.info("Successfully deleted all snapshots")
-
-        # Disable uss for volume
-        g.log.info("Disabling uss for volume")
-        ret, _, _ = disable_uss(self.mnode, self.volname)
-        if ret != 0:
-            raise ExecutionError("Failed to disable uss")
-        g.log.info("Successfully disabled uss for volume"
-                   "%s", self.volname)
-
-        # Unmount and cleanup original volume
-        g.log.info("Starting to Unmount and Cleanup Volume")
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to umount and cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-    def test_uss_snap_active_deactive(self):
-
-        # pylint: disable=too-many-statements
         """
         Steps:
         * Create volume
         * Mount volume
         * Perform I/O on mounts
-        * Create 2 snapshots snapy1 & snapy2
+        * Create 2 snapshots.
         * Validate snap created
         * Enable USS
         * Validate USS is enabled
         * Validate snapd is running
-        * Activate snapy1 & snapy2
+        * Activate the snapshots.
         * List snaps under .snap directory
-          -- snap1 and snap2 should be listed under .snaps
-        * Deactivate snapy2
+          -- previously created snaps should be listed under .snaps
+        * Deactivate one of the snapshot
         * List snaps under .snap directory
-          -- snapy2 is not listed as it is deactivated
-        * Activate snapy2
+          -- snapshot is not listed as it is deactivated
+        * Activate the deactivated snapshot
         * List snaps under .snap directory
-          -- snap1 and snap2 should be listed under .snaps
+          -- both snapshots should be listed under .snaps
         """
-
         # Perform I/O
-        g.log.info("Starting IO on all mounts...")
-        self.counter = 1
+        redant.logger.info("Starting IO on all mounts...")
+        counter = 1
         self.all_mounts_procs = []
-        for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dirname-start-num %d "
-                   "--dir-depth 2 "
-                   "--dir-length 2 "
-                   "--max-num-of-dirs 2 "
-                   "--num-of-files 2 %s" % (
-                       self.script_upload_path,
-                       self.counter, mount_obj.mountpoint))
+        self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
 
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
+        for mount in self.mounts:
+            proc = redant.create_deep_dirs_with_files(mount['mountpath'],
+                                                      counter, 2, 3, 3, 10,
+                                                      mount['client'])
             self.all_mounts_procs.append(proc)
-        self.io_validation_complete = False
+            counter += 10
 
-        # Validate IO
-        g.log.info("Wait for IO to complete and validate IO ...")
-        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
-        self.assertTrue(ret, "IO failed on some of the clients")
-        self.io_validation_complete = True
-        g.log.info("I/O successful on clients")
+        # Wait till IO finishes.
+        if not redant.validate_io_procs(self.all_mounts_procs, self.mounts):
+            raise Exception("IO failed")
 
         # Enable USS
-        g.log.info("Enable USS on volume")
-        ret, _, _ = enable_uss(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to enable USS on volume")
-        g.log.info("Successfully enabled USS on volume")
+        redant.enable_uss(self.vol_name, self.server_list[0])
 
         # Validate USS is enabled
-        g.log.info("Validating USS is enabled")
-        ret = is_uss_enabled(self.mnode, self.volname)
-        self.assertTrue(ret, "USS is disabled on volume "
-                        "%s" % self.volname)
-        g.log.info("USS enabled on volume %s", self.volname)
+        if not redant.is_uss_enabled(self.vol_name, self.server_list[0]):
+            raise Exception("USS is not enabled.")
 
         # Validate snapd running
-        for server in self.servers:
-            g.log.info("Validating snapd daemon on:%s", server)
-            ret = is_snapd_running(server, self.volname)
-            self.assertTrue(ret, "Snapd is Not running on "
-                            "%s" % server)
-            g.log.info("Snapd Running on node: %s", server)
+        for server in self.server_list:
+            if not redant.is_snapd_running(self.vol_name, server):
+                raise Exception(f"Snapd not running in {server}")
 
         # Create 2 snapshot
-        g.log.info("Creating 2 snapshots for volume %s", self.volname)
         for i in range(1, 3):
-            ret, _, _ = snap_create(self.mnode, self.volname, "snapy%s" % i)
-            self.assertEqual(ret, 0, ("Failed to create snapshot for %s"
-                                      % self.volname))
-            g.log.info("Snapshot %s created successfully for volume  %s",
-                       "snapy%s" % i, self.volname)
+            snap_name = f"{self.vol_name}-snap{i}"
+            redant.snap_create(self.vol_name, snap_name,
+                               self.server_list[0])
 
         # Check for no of snaps using snap_list it should be 2 now
-        snap_list = get_snap_list(self.mnode)
-        self.assertEqual(2, len(snap_list), "No of snaps not consistent "
-                         "for volume %s" % self.volname)
-        g.log.info("Successfully validated number of snaps.")
+        snap_list = redant.get_snap_list(self.server_list[0], self.vol_name)
+        if len(snap_list) != 2:
+            raise Exception("Snap list should have 2 snap volumes. But instead"
+                            f" is {snap_list}")
 
-        # Activate snapshot snapy1 & snapy2
-        g.log.info("Activating snapshot snapy1 & snapy2")
+        # Activate snapshots
         for i in range(1, 3):
-            ret, _, _ = snap_activate(self.mnode, "snapy%s" % i)
-            self.assertEqual(ret, 0, "Failed to activate snapshot snapy%s" % i)
-        g.log.info("Both snapshots activated successfully")
+            snap_name = f"{self.vol_name}-snap{i}"
+            redant.snap_activate(snap_name, self.server_list[0])
 
         # list activated snapshots directory under .snaps
-        g.log.info("Listing activated snapshots under .snaps")
-        for mount_obj in self.mounts:
-            ret, out, _ = uss_list_snaps(mount_obj.client_system,
-                                         mount_obj.mountpoint)
-            self.assertEqual(ret, 0, "Directory Listing Failed for"
-                             " Activated Snapshot")
-            validate_dir = out.split('\n')
-            self.assertIn("snapy1", validate_dir, "Failed to "
-                          "validate snapy1 under .snaps directory")
-            g.log.info("Activated Snapshot snapy1 listed Successfully")
-            self.assertIn("snapy2", validate_dir, "Successfully listed"
-                          " snapy2 under.snaps directory")
-            g.log.info("Expected: De-activated Snapshot not listed")
+        if not redant.view_snap_from_mount(self.mounts, snap_list):
+            raise Exception("Snap in .snaps doesn't match snap list provided")
 
-        # Deactivate snapshot snapy2
-        g.log.info("Deactivating snapshot snapy2")
-        ret, _, _ = snap_deactivate(self.mnode, "snapy2")
-        self.assertEqual(ret, 0, "Failed to deactivate snapshot snapy2")
-        g.log.info("Successfully deactivated snapshot snapy2")
+        # Deactivate the second snapshot
+        redant.snap_deactivate(snap_list[1], self.server_list[0])
 
-        # validate snapy2 should not present in mountpoint
-        ret = view_snaps_from_mount(self.mounts, "snapy2")
-        self.assertFalse(ret, " UnExpected : Still able to View snapy2"
-                         " from mount ")
-        g.log.info("Successfully verified deactivated snapshot "
-                   "snapy2 is not listed")
+        # validate the given snap is absent in mountpoint
+        if redant.view_snaps_from_mount(self.mounts, snap_list[1], False):
+            raise Exception(f"Snap {snap_list[1]} shouldn't be present under"
+                            ".snaps dir")
 
-        # Activate snapshot snapy2
-        ret, _, _ = snap_activate(self.mnode, "snapy2")
-        self.assertEqual(ret, 0, "Failed to activate Snapshot snapy2")
-        g.log.info("Snapshot snapy2 activated successfully")
+        # Activate snapshot the second snapshot
+        redant.snap_activate(snap_list[1], self.server_list[0])
 
         # list activated snapshots directory under .snaps
-        g.log.info("Listing activated snapshots under .snaps")
-        for mount_obj in self.mounts:
-            ret, out, _ = uss_list_snaps(mount_obj.client_system,
-                                         mount_obj.mountpoint)
-            self.assertEqual(ret, 0, "Directory Listing Failed for"
-                             " Activated Snapshot")
-            validate_dir = out.split('\n')
-            self.assertIn("snapy1", validate_dir, "Failed to "
-                          "validate snapy%s under .snaps directory")
-            g.log.info("Activated Snapshot listed Successfully")
-            self.assertIn("snapy2", validate_dir, "Successfully listed"
-                          "snapy2 under .snaps directory")
-            g.log.info("Expected: De-activated Snapshot not listed")
+        if not redant.view_snap_from_mount(self.mounts, snap_list):
+            raise Exception("Snap in .snaps doesn't match snap list provided")


### PR DESCRIPTION
Migrated TC [test_uss_snap_activate_deactivate](https://github.com/gluster/glusto-tests/blob/master/tests/functional/snapshot/test_uss_snap_active_deactive.py)

Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>
