### PR TITLE
Migrate TC test_ec_brick_consumable_size.py

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -599,7 +599,7 @@ class IoOps(AbstractOps):
 
         cmd = (f"df {mountpoint} | grep -v '^Filesystem' | "
                "awk '{print $4}'")
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, False)
         if ret['error_code'] != 0:
             self.logger.error("Failed to get size of mountpoint {mountpoint}"
                               f" on {node}")

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -587,6 +587,26 @@ class IoOps(AbstractOps):
                                  f"{mount['mountpath']}")
         return _rc
 
+    def get_size_of_mountpoint(self, mountpoint: str, node: str) -> list:
+        """
+        Returns the size in blocks for the mount point
+        Args:
+            node - node on which path is mounted
+            mounts - mount point path
+        Returns:
+            Size of the mount point in blocks or none.
+        """
+
+        cmd = (f"df {mountpoint} | grep -v '^Filesystem' | "
+               "awk '{print $4}'")
+        ret = self.execute_abstract_op_node(cmd, node)
+        if ret['error_code'] != 0:
+            self.logger.error("Failed to get size of mountpoint {mountpoint}"
+                              f" on {node}")
+            return None
+
+        return ret['msg'][0].split("\n")[0]
+
     def list_all_files_and_dirs_mounts(self, mounts: list) -> bool:
         """List all Files and Directories from mounts.
         Args:

--- a/config/config.yml
+++ b/config/config.yml
@@ -72,3 +72,4 @@ excluded_tests:
     - tests/functional/snapshot/test_validate_snap_del_gd_down.py # Requires downstream RHGS installation
     - tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py # Requires downstream RHGS installation
     - tests/functional/disperse/test_ec_uss_snapshot.py # Excluded due to bz: 1828820
+    - tests/functional/disperse/test_ec_brick_consumable_size.py # Excluded due to bz: 1883429

--- a/tests/functional/disperse/test_ec_brick_consumable_size.py
+++ b/tests/functional/disperse/test_ec_brick_consumable_size.py
@@ -1,88 +1,81 @@
-#  Copyright (C) 2018-2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-EcBrickConsumableSize:
+  Copyright (C) 2018-2020 Red Hat, Inc. <http://www.redhat.com>
 
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+EcBrickConsumableSize:
     This test verifies that the size of the volume will be
     'number of data bricks * least of brick size'.
-
 """
-from unittest import skip
-from glusto.core import Glusto as g
-from glustolibs.gluster.brick_libs import (get_all_bricks,
-                                           bring_bricks_offline)
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.volume_libs import (get_volume_info)
-from glustolibs.gluster.lib_utils import get_size_of_mountpoint
-from glustolibs.gluster.gluster_base_class import (GlusterBaseClass, runs_on)
+
+# disruptive;disp,dist-disp
+
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['dispersed', 'distributed-dispersed'], ['glusterfs']])
-class EcBrickConsumableSize(GlusterBaseClass):
-
-    # Method to setup the environment for test case
-    def setUp(self):
-        # Setup Volume and Mount Volume
-        g.log.info("Starting to Setup Volume and Mount Volume")
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
-        g.log.info("Successful in Setup Volume and Mount Volume")
-
+class TestCase(DParentTest):
     def _get_min_brick(self):
         # Returns the brick with min size
-        bricks_list = get_all_bricks(self.mnode, self.volname)
+        bricks_list = self.redant.get_all_bricks(self.vol_name,
+                                                 self.server_list[0])
         min_brick_size = -1
-        min_size_brick = None
+        min_brick = None
         for brick in bricks_list:
             brick_node, brick_path = brick.split(":")
-            brick_size = get_size_of_mountpoint(brick_node, brick_path)
-            if ((brick_size is not None) and (min_brick_size == -1) or
-                    (int(min_brick_size) > int(brick_size))):
+            brick_size = self.redant.get_size_of_mountpoint(brick_path,
+                                                            brick_node)
+            if ((brick_size) and (min_brick_size == -1)
+                    or (int(min_brick_size) > int(brick_size))):
                 min_brick_size = brick_size
-                min_size_brick = brick
-        return min_size_brick, min_brick_size
+                min_brick = brick
+        return min_brick, min_brick_size
 
     def _get_consumable_vol_size(self, min_brick_size):
         # Calculates the consumable size of the volume created
-        vol_info = get_volume_info(self.mnode, self.volname)
-        self.assertIsNotNone(vol_info, ("Unable to get the volinfo \
-                    of %s.", self.volname))
-        disp_data_bricks = (int(vol_info[self.volname]['disperseCount']) -
-                            int(vol_info[self.volname]['redundancyCount']))
-        dist_count = (int(vol_info[self.volname]['brickCount']) /
-                      int(vol_info[self.volname]['disperseCount']))
-        consumable_size = ((int(min_brick_size) * int(disp_data_bricks)) *
-                           int(dist_count))
+        vol_info = self.redant.get_volume_info(self.server_list[0],
+                                               self.vol_name)
+        if not vol_info:
+            raise Exception('Not able to get volume info')
+
+        disp_data_bricks = (int(vol_info[self.vol_name]['disperseCount'])
+                            - int(vol_info[self.vol_name]['redundancyCount']))
+        dist_count = int(vol_info[self.vol_name]['distCount'])
+        consumable_size = ((int(min_brick_size) * int(disp_data_bricks))
+                           * int(dist_count))
         return consumable_size, dist_count
 
-    @skip('Skipping this test due to Bug 1883429')
-    def test_disperse_vol_size(self):
-        # pylint: disable=too-many-locals
-        client = self.mounts[0].client_system
-        mount_point = self.mounts[0].mountpoint
-
+    def run_test(self, redant):
+        """
+        1. Obtain the volume size
+        2. Retrieve the minimum brick size
+        3. Calculate the consumable size
+        4. Verify the volume size
+        5. Write to the available size and try to write more
+        6. Cleanup the mounts to verify
+        7. Vol size after bringing down the brick with smallest size should
+           not be greater than the actual size
+        """
         # Obtain the volume size
-        vol_size = get_size_of_mountpoint(client, mount_point)
-        self.assertIsNotNone(vol_size, ("Unable to get the volsize "
-                                        "of %s.", self.volname))
+        client = self.client_list[0]
+        mpoint = self.mountpoint
+        vol_size = redant.get_size_of_mountpoint(mpoint, client)
+        if not vol_size:
+            raise Exception(f"Unable to get the volsize of {self.volname}")
 
         # Retrieve the minimum brick size
-        min_size_brick, min_brick_size = self._get_min_brick()
+        min_brick, min_brick_size = self._get_min_brick()
 
         # Calculate the consumable size
         consumable_size, dist_count = (
@@ -91,53 +84,42 @@ class EcBrickConsumableSize(GlusterBaseClass):
         # Verify the volume size is in allowable range
         # Volume size should be above 98% of consumable size.
         delta = (100 - ((float(vol_size)/float(consumable_size)) * 100))
-        self.assertTrue(delta < 2, "Volume size is not in allowable range")
-        g.log.info("Volume size is in allowable range")
+        if delta >= 2:
+            raise Exception("Volume size is not in allowable range")
 
         # Write to the available size
         block_size = 1024
-        write_size = ((int(vol_size) * 0.95 * int(block_size)) /
-                      (int(dist_count)))
-        for i in range(1, int(dist_count)):
-            ret, _, _ = g.run(client, "fallocate -l {} {}/testfile{} "
-                              .format(int(write_size), mount_point, i))
-            self.assertTrue(ret == 0, ("Writing file of available size "
-                                       "failed on volume %s", self.volname))
-        g.log.info("Successfully verified volume size")
+        write_size = ((int(vol_size) * 0.95 * int(block_size))
+                      / (int(dist_count)))
+        for i in range(0, dist_count):
+            cmd = f'fallocate -l {write_size} {mpoint}/testfile{i}'
+            redant.execute_abstract_op_node(cmd, client)
 
         # Try writing more than the available size
         write_size = ((int(vol_size) * int(block_size)) * 1.2)
-        ret, _, _ = g.run(client, "fallocate -l {} {}/testfile1 "
-                          .format(int(write_size), mount_point))
-        self.assertTrue(ret != 0, ("Writing file of more than available "
-                                   "size passed on volume %s", self.volname))
-        g.log.info("Successfully verified brick consumable size")
+        cmd = f'fallocate -l {write_size} {mpoint}/testfile2'
+        ret = redant.execute_abstract_op_node(cmd, client, False)
+        if ret['error_code'] != 0:
+            raise Exception("Writing file of more than available "
+                            "size passed on volume %s")
 
         # Cleanup the mounts to verify
-        cmd = ('rm -rf %s' % mount_point)
-        ret, _, _ = g.run(client, cmd)
-        if ret:
-            g.log.error("Failed to cleanup vol data on %s", mount_point)
+        cmd = (f'rm -rf -v {self.mountpoint}/*')
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
+
         # Bring down the smallest brick
-        ret = bring_bricks_offline(self.volname, min_size_brick)
-        self.assertTrue(ret, "Failed to bring down the smallest brick")
+        redant.bring_bricks_offline(self.vol_name, min_brick)
+        if not redant.are_bricks_offline(self.vol_name, min_brick,
+                                         self.server_list[0]):
+            raise Exception(f"Bricks {min_brick} are not offline")
 
         # Find the volume size post brick down
-        post_vol_size = get_size_of_mountpoint(client, mount_point)
-        self.assertIsNotNone(post_vol_size, ("Unable to get the volsize "
-                                             "of %s.", self.volname))
+        post_vol_size = redant.get_size_of_mountpoint(mpoint, client)
+        if not post_vol_size:
+            raise Exception(f"Unable to get the volsize of {self.volname}")
 
         # Vol size after bringing down the brick with smallest size should
         # not be greater than the actual size
-        self.assertGreater(vol_size, post_vol_size,
-                           ("The volume size after bringing down the volume "
-                            "is greater than the initial"))
-
-    # Method to cleanup test setup
-    def tearDown(self):
-        # Stopping the volume
-        g.log.info("Starting to Unmount Volume and Cleanup Volume")
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Unmount Volume and Cleanup Volume")
-        g.log.info("Successful in Unmount Volume and Cleanup Volume")
+        if post_vol_size >= vol_size:
+            raise Exception("The volume size after bringing down the volume "
+                            "is greater than the initial")

--- a/tests/functional/disperse/test_ec_brick_consumable_size.py
+++ b/tests/functional/disperse/test_ec_brick_consumable_size.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2018-2020 Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,8 +21,10 @@ EcBrickConsumableSize:
     'number of data bricks * least of brick size'.
 
 """
+from unittest import skip
 from glusto.core import Glusto as g
-from glustolibs.gluster.brick_libs import get_all_bricks
+from glustolibs.gluster.brick_libs import (get_all_bricks,
+                                           bring_bricks_offline)
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.volume_libs import (get_volume_info)
 from glustolibs.gluster.lib_utils import get_size_of_mountpoint
@@ -41,67 +43,95 @@ class EcBrickConsumableSize(GlusterBaseClass):
             raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
         g.log.info("Successful in Setup Volume and Mount Volume")
 
-    # Test Case
-    def test_disperse_vol_size(self):
-        # pylint: disable=too-many-locals
-        mnode = self.mnode
-        volname = self.volname
-        client = self.mounts[0].client_system
-        mountpoint = self.mounts[0].mountpoint
-
-        # Obtain the volume size
-        vol_size = get_size_of_mountpoint(client, mountpoint)
-        self.assertIsNotNone(vol_size, ("Unable to get the volsize \
-                    of %s.", volname))
-
-        # Retrieve the minimum brick size
+    def _get_min_brick(self):
+        # Returns the brick with min size
+        bricks_list = get_all_bricks(self.mnode, self.volname)
         min_brick_size = -1
-        bricks_list = get_all_bricks(mnode, volname)
+        min_size_brick = None
         for brick in bricks_list:
             brick_node, brick_path = brick.split(":")
             brick_size = get_size_of_mountpoint(brick_node, brick_path)
             if ((brick_size is not None) and (min_brick_size == -1) or
                     (int(min_brick_size) > int(brick_size))):
                 min_brick_size = brick_size
+                min_size_brick = brick
+        return min_size_brick, min_brick_size
 
-        # Calculate the consumable size
-        vol_info = get_volume_info(mnode, volname)
+    def _get_consumable_vol_size(self, min_brick_size):
+        # Calculates the consumable size of the volume created
+        vol_info = get_volume_info(self.mnode, self.volname)
         self.assertIsNotNone(vol_info, ("Unable to get the volinfo \
-                    of %s.", volname))
-
-        disp_data_bricks = (int(vol_info[volname]['disperseCount']) -
-                            int(vol_info[volname]['redundancyCount']))
-        dist_count = (int(vol_info[volname]['brickCount']) /
-                      int(vol_info[volname]['disperseCount']))
+                    of %s.", self.volname))
+        disp_data_bricks = (int(vol_info[self.volname]['disperseCount']) -
+                            int(vol_info[self.volname]['redundancyCount']))
+        dist_count = (int(vol_info[self.volname]['brickCount']) /
+                      int(vol_info[self.volname]['disperseCount']))
         consumable_size = ((int(min_brick_size) * int(disp_data_bricks)) *
                            int(dist_count))
+        return consumable_size, dist_count
+
+    @skip('Skipping this test due to Bug 1883429')
+    def test_disperse_vol_size(self):
+        # pylint: disable=too-many-locals
+        client = self.mounts[0].client_system
+        mount_point = self.mounts[0].mountpoint
+
+        # Obtain the volume size
+        vol_size = get_size_of_mountpoint(client, mount_point)
+        self.assertIsNotNone(vol_size, ("Unable to get the volsize "
+                                        "of %s.", self.volname))
+
+        # Retrieve the minimum brick size
+        min_size_brick, min_brick_size = self._get_min_brick()
+
+        # Calculate the consumable size
+        consumable_size, dist_count = (
+            self._get_consumable_vol_size(min_brick_size))
 
         # Verify the volume size is in allowable range
         # Volume size should be above 98% of consumable size.
         delta = (100 - ((float(vol_size)/float(consumable_size)) * 100))
-        self.assertTrue(delta < 2, ("Volume size is not in allowable range"))
-
+        self.assertTrue(delta < 2, "Volume size is not in allowable range")
         g.log.info("Volume size is in allowable range")
 
         # Write to the available size
         block_size = 1024
-        write_size = ((int(vol_size) * (0.95) * int(block_size)) /
+        write_size = ((int(vol_size) * 0.95 * int(block_size)) /
                       (int(dist_count)))
         for i in range(1, int(dist_count)):
-            ret, _, _ = g.run(client, "fallocate -l {} {}/testfile{} \
-                       ".format(int(write_size), mountpoint, i))
-            self.assertTrue(ret == 0, ("Writing file of available size failed \
-                    on volume %s", volname))
+            ret, _, _ = g.run(client, "fallocate -l {} {}/testfile{} "
+                              .format(int(write_size), mount_point, i))
+            self.assertTrue(ret == 0, ("Writing file of available size "
+                                       "failed on volume %s", self.volname))
         g.log.info("Successfully verified volume size")
 
         # Try writing more than the available size
         write_size = ((int(vol_size) * int(block_size)) * 1.2)
-        ret, _, _ = g.run(client, "fallocate -l {} {}/testfile1 \
-                    ".format(int(write_size), mountpoint))
-        self.assertTrue(ret != 0, ("Writing file of more than available \
-                                   size passed on volume %s", volname))
-
+        ret, _, _ = g.run(client, "fallocate -l {} {}/testfile1 "
+                          .format(int(write_size), mount_point))
+        self.assertTrue(ret != 0, ("Writing file of more than available "
+                                   "size passed on volume %s", self.volname))
         g.log.info("Successfully verified brick consumable size")
+
+        # Cleanup the mounts to verify
+        cmd = ('rm -rf %s' % mount_point)
+        ret, _, _ = g.run(client, cmd)
+        if ret:
+            g.log.error("Failed to cleanup vol data on %s", mount_point)
+        # Bring down the smallest brick
+        ret = bring_bricks_offline(self.volname, min_size_brick)
+        self.assertTrue(ret, "Failed to bring down the smallest brick")
+
+        # Find the volume size post brick down
+        post_vol_size = get_size_of_mountpoint(client, mount_point)
+        self.assertIsNotNone(post_vol_size, ("Unable to get the volsize "
+                                             "of %s.", self.volname))
+
+        # Vol size after bringing down the brick with smallest size should
+        # not be greater than the actual size
+        self.assertGreater(vol_size, post_vol_size,
+                           ("The volume size after bringing down the volume "
+                            "is greater than the initial"))
 
     # Method to cleanup test setup
     def tearDown(self):

--- a/tests/functional/disperse/test_ec_brick_consumable_size.py
+++ b/tests/functional/disperse/test_ec_brick_consumable_size.py
@@ -1,0 +1,113 @@
+#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+EcBrickConsumableSize:
+
+    This test verifies that the size of the volume will be
+    'number of data bricks * least of brick size'.
+
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.brick_libs import get_all_bricks
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_libs import (get_volume_info)
+from glustolibs.gluster.lib_utils import get_size_of_mountpoint
+from glustolibs.gluster.gluster_base_class import (GlusterBaseClass, runs_on)
+
+
+@runs_on([['dispersed', 'distributed-dispersed'], ['glusterfs']])
+class EcBrickConsumableSize(GlusterBaseClass):
+
+    # Method to setup the environment for test case
+    def setUp(self):
+        # Setup Volume and Mount Volume
+        g.log.info("Starting to Setup Volume and Mount Volume")
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
+        g.log.info("Successful in Setup Volume and Mount Volume")
+
+    # Test Case
+    def test_disperse_vol_size(self):
+        # pylint: disable=too-many-locals
+        mnode = self.mnode
+        volname = self.volname
+        client = self.mounts[0].client_system
+        mountpoint = self.mounts[0].mountpoint
+
+        # Obtain the volume size
+        vol_size = get_size_of_mountpoint(client, mountpoint)
+        self.assertIsNotNone(vol_size, ("Unable to get the volsize \
+                    of %s.", volname))
+
+        # Retrieve the minimum brick size
+        min_brick_size = -1
+        bricks_list = get_all_bricks(mnode, volname)
+        for brick in bricks_list:
+            brick_node, brick_path = brick.split(":")
+            brick_size = get_size_of_mountpoint(brick_node, brick_path)
+            if ((brick_size is not None) and (min_brick_size == -1) or
+                    (int(min_brick_size) > int(brick_size))):
+                min_brick_size = brick_size
+
+        # Calculate the consumable size
+        vol_info = get_volume_info(mnode, volname)
+        self.assertIsNotNone(vol_info, ("Unable to get the volinfo \
+                    of %s.", volname))
+
+        disp_data_bricks = (int(vol_info[volname]['disperseCount']) -
+                            int(vol_info[volname]['redundancyCount']))
+        dist_count = (int(vol_info[volname]['brickCount']) /
+                      int(vol_info[volname]['disperseCount']))
+        consumable_size = ((int(min_brick_size) * int(disp_data_bricks)) *
+                           int(dist_count))
+
+        # Verify the volume size is in allowable range
+        # Volume size should be above 98% of consumable size.
+        delta = (100 - ((float(vol_size)/float(consumable_size)) * 100))
+        self.assertTrue(delta < 2, ("Volume size is not in allowable range"))
+
+        g.log.info("Volume size is in allowable range")
+
+        # Write to the available size
+        block_size = 1024
+        write_size = ((int(vol_size) * (0.95) * int(block_size)) /
+                      (int(dist_count)))
+        for i in range(1, int(dist_count)):
+            ret, _, _ = g.run(client, "fallocate -l {} {}/testfile{} \
+                       ".format(int(write_size), mountpoint, i))
+            self.assertTrue(ret == 0, ("Writing file of available size failed \
+                    on volume %s", volname))
+        g.log.info("Successfully verified volume size")
+
+        # Try writing more than the available size
+        write_size = ((int(vol_size) * int(block_size)) * 1.2)
+        ret, _, _ = g.run(client, "fallocate -l {} {}/testfile1 \
+                    ".format(int(write_size), mountpoint))
+        self.assertTrue(ret != 0, ("Writing file of more than available \
+                                   size passed on volume %s", volname))
+
+        g.log.info("Successfully verified brick consumable size")
+
+    # Method to cleanup test setup
+    def tearDown(self):
+        # Stopping the volume
+        g.log.info("Starting to Unmount Volume and Cleanup Volume")
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Unmount Volume and Cleanup Volume")
+        g.log.info("Successful in Unmount Volume and Cleanup Volume")

--- a/tests/functional/disperse/test_ec_fops.py
+++ b/tests/functional/disperse/test_ec_fops.py
@@ -187,10 +187,8 @@ class TestFops(DParentTest):
 
         # Creating 2TB file if volume is greater
         # than equal to 3TB
-        command = (f"df {self.mountpoint} | grep -v '^Filesystem' |"
-                   " awk '{print $4}'")
-        ret = redant.execute_abstract_op_node(command, self.client_list[0])
-        avail = ret['msg'][0].split("\n")[0]
+        avail = redant.get_size_of_mountpoint(self.mountpoint,
+                                              self.client_list[0])
         if int(avail) >= 3000000000:
             cmd = f'fallocate -l 2TB {self.mountpoint}/tiny_file_large.txt'
             redant.execute_abstract_op_node(cmd, self.client_list[0])


### PR DESCRIPTION
[Migrate TC test_ec_brick_consumable_size.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/disperse/test_ec_brick_consumable_size.py)

Updates: #292
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>