### PR TITLE
Migrate TC test_verify_rebalance_with_locks_on_files.py

### DIFF
--- a/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py
+++ b/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py
@@ -16,12 +16,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-# nonDisruptive;dist,dist-rep
+# disruptive;dist,dist-rep
 
-from tests.nd_parent_test import NdParentTest
+from tests.d_parent_test import DParentTest
 
 
-class TestCase(NdParentTest):
+class TestCase(DParentTest):
 
     def _create_file_and_hold_lock(self):
         """ Creates a file and holds lock on the file created"""

--- a/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py
+++ b/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py
@@ -1,0 +1,123 @@
+#  Copyright (C) 2021 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_libs import expand_volume
+from glustolibs.gluster.rebalance_ops import (rebalance_start,
+                                              wait_for_rebalance_to_complete)
+from glustolibs.misc.misc_libs import upload_scripts
+
+
+@runs_on([['distributed', 'distributed-replicated'],
+          ['glusterfs']])
+class TestVerifyRebalanceWithFileLock(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        # Calling GlusterBaseClass setUpClass
+        cls.get_super_method(cls, 'setUpClass')()
+        cls.script = "/usr/share/glustolibs/io/scripts/file_lock.py"
+        if not upload_scripts(cls.clients, [cls.script]):
+            raise ExecutionError("Failed to upload IO scripts to clients %s"
+                                 % cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+    def setUp(self):
+        """
+        Setup and mount volume
+        """
+        self.get_super_method(self, 'setUp')()
+
+        # Setup Volume
+        if not self.setup_volume_and_mount_volume(mounts=[self.mounts[0]]):
+            raise ExecutionError("Failed to Setup and Mount Volume")
+
+        self.m_point = self.mounts[0].mountpoint
+        self.first_client = self.mounts[0].client_system
+        self.lock_cmd = ("/usr/bin/env python {} -f {}/test_file -t 200"
+                         .format(self.script, self.m_point))
+
+    def _create_file_and_hold_lock(self):
+        """ Creates a file and holds lock on the file created"""
+        cmd = ("cd {}; dd if=/dev/zero of=test_file bs=10M count=1;"
+               .format(self.m_point))
+        ret, _, _ = g.run(self.first_client, cmd)
+        self.assertEqual(ret, 0, "Failed to create file")
+
+        # Acquire lock to the file created
+        self.proc = g.run_async(self.first_client, self.lock_cmd)
+
+    def _expand_volume_and_verify_rebalance(self):
+        """ Expands the volume, trigger rebalance and verify file is copied"""
+
+        # Expand the volume
+        ret = expand_volume(self.mnode, self.volname, self.servers,
+                            self.all_servers_info)
+        self.assertTrue(ret, "Failed to expand the volume")
+
+        # Trigger rebalance
+        ret, _, _ = rebalance_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
+                         % self.volname)
+
+        # Wait for rebalance to complete
+        ret = wait_for_rebalance_to_complete(self.mnode, self.volname,
+                                             timeout=1200)
+        self.assertTrue(ret, "Rebalance is not yet complete on the volume "
+                             "%s" % self.volname)
+        g.log.info("Rebalance successfully completed")
+
+    def _verify_file_lock(self):
+        """ Verifies file lock on file before been released by 1st program"""
+
+        ret, _, _ = g.run(self.mounts[0].client_system, self.lock_cmd)
+        self.assertEqual(ret, 1, "Unexpected: acquired lock before released")
+        g.log.info("Expected : Lock can't be acquired before being released")
+
+        # Wait till the lock is been released
+        ret, _, _ = self.proc.async_communicate()
+        self.assertEqual(ret, 0, "File lock process failed")
+
+    def test_verify_rebalance_with_file_lock(self):
+        """
+        Steps:
+        1. Create a distributed or distributed-replicate volume and
+           populate some data
+        2. Hold exclusive lock on a file (can use flock)
+        3. Add-brick and rebalance (make sure this file gets migrated)
+        4. Again from another program try to hold exclusive lock on this file
+        """
+        # Create a File
+        self._create_file_and_hold_lock()
+
+        # Expand the volume
+        self._expand_volume_and_verify_rebalance()
+
+        # Try getting lock to the file while the lock is still held by another
+        self._verify_file_lock()
+
+    def tearDown(self):
+        # Unmount and cleanup original volume
+        if not self.unmount_volume_and_cleanup_volume(mounts=[self.mounts[0]]):
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py
+++ b/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py
@@ -1,101 +1,71 @@
-#  Copyright (C) 2021 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2021 Red Hat, Inc. <http://www.redhat.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+
+# nonDisruptive;dist,dist-rep
+
+from tests.nd_parent_test import NdParentTest
 
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_libs import expand_volume
-from glustolibs.gluster.rebalance_ops import (rebalance_start,
-                                              wait_for_rebalance_to_complete)
-from glustolibs.misc.misc_libs import upload_scripts
-
-
-@runs_on([['distributed', 'distributed-replicated'],
-          ['glusterfs']])
-class TestVerifyRebalanceWithFileLock(GlusterBaseClass):
-
-    @classmethod
-    def setUpClass(cls):
-        # Calling GlusterBaseClass setUpClass
-        cls.get_super_method(cls, 'setUpClass')()
-        cls.script = "/usr/share/glustolibs/io/scripts/file_lock.py"
-        if not upload_scripts(cls.clients, [cls.script]):
-            raise ExecutionError("Failed to upload IO scripts to clients %s"
-                                 % cls.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   cls.clients)
-
-    def setUp(self):
-        """
-        Setup and mount volume
-        """
-        self.get_super_method(self, 'setUp')()
-
-        # Setup Volume
-        if not self.setup_volume_and_mount_volume(mounts=[self.mounts[0]]):
-            raise ExecutionError("Failed to Setup and Mount Volume")
-
-        self.m_point = self.mounts[0].mountpoint
-        self.first_client = self.mounts[0].client_system
-        self.lock_cmd = ("/usr/bin/env python {} -f {}/test_file -t 200"
-                         .format(self.script, self.m_point))
+class TestCase(NdParentTest):
 
     def _create_file_and_hold_lock(self):
         """ Creates a file and holds lock on the file created"""
-        cmd = ("cd {}; dd if=/dev/zero of=test_file bs=10M count=1;"
-               .format(self.m_point))
-        ret, _, _ = g.run(self.first_client, cmd)
-        self.assertEqual(ret, 0, "Failed to create file")
+        cmd = (f"cd {self.mountpoint}; dd if=/dev/zero of=test_file "
+               "bs=10M count=1;")
+        self.redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Acquire lock to the file created
-        self.proc = g.run_async(self.first_client, self.lock_cmd)
+        self.proc = self.redant.execute_command_async(self.lock_cmd,
+                                                      self.client_list[0])
 
     def _expand_volume_and_verify_rebalance(self):
         """ Expands the volume, trigger rebalance and verify file is copied"""
 
         # Expand the volume
-        ret = expand_volume(self.mnode, self.volname, self.servers,
-                            self.all_servers_info)
-        self.assertTrue(ret, "Failed to expand the volume")
+        if not (self.redant.expand_volume(self.server_list[0], self.vol_name,
+                self.server_list, self.brick_roots)):
+            raise Exception("Failed to expand volume")
 
-        # Trigger rebalance
-        ret, _, _ = rebalance_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
-                         % self.volname)
+        # Trigger rebalance and wait for it to complete
+        self.redant.rebalance_start(self.vol_name, self.server_list[0])
 
         # Wait for rebalance to complete
-        ret = wait_for_rebalance_to_complete(self.mnode, self.volname,
-                                             timeout=1200)
-        self.assertTrue(ret, "Rebalance is not yet complete on the volume "
-                             "%s" % self.volname)
-        g.log.info("Rebalance successfully completed")
+        if not (self.redant.wait_for_rebalance_to_complete(self.vol_name,
+                                                           self.server_list[0],
+                                                           timeout=1200)):
+            raise Exception("Rebalance operation has not yet completed.")
 
     def _verify_file_lock(self):
         """ Verifies file lock on file before been released by 1st program"""
 
-        ret, _, _ = g.run(self.mounts[0].client_system, self.lock_cmd)
-        self.assertEqual(ret, 1, "Unexpected: acquired lock before released")
-        g.log.info("Expected : Lock can't be acquired before being released")
+        ret = self.redant.execute_abstract_op_node(self.lock_cmd,
+                                                   self.client_list[0],
+                                                   False)
+        if ret['error_code'] == 0:
+            raise Exception("Unexpected: Another program acquired the "
+                            "lock before been released by 1st one")
 
         # Wait till the lock is been released
-        ret, _, _ = self.proc.async_communicate()
-        self.assertEqual(ret, 0, "File lock process failed")
+        ret = self.redant.wait_till_async_command_ends(self.proc)
+        if ret['error_code'] != 0:
+            raise Exception("File lock process failed.")
 
-    def test_verify_rebalance_with_file_lock(self):
+    def run_test(self, redant):
         """
         Steps:
         1. Create a distributed or distributed-replicate volume and
@@ -105,6 +75,9 @@ class TestVerifyRebalanceWithFileLock(GlusterBaseClass):
         4. Again from another program try to hold exclusive lock on this file
         """
         # Create a File
+        self.lock_cmd = ("python3 /usr/share/redant/script/file_lock.py "
+                         f"-f {self.mountpoint}/test_file -t 200")
+
         self._create_file_and_hold_lock()
 
         # Expand the volume
@@ -112,12 +85,5 @@ class TestVerifyRebalanceWithFileLock(GlusterBaseClass):
 
         # Try getting lock to the file while the lock is still held by another
         self._verify_file_lock()
-
-    def tearDown(self):
-        # Unmount and cleanup original volume
-        if not self.unmount_volume_and_cleanup_volume(mounts=[self.mounts[0]]):
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        redant.logger.info("TC succecful to check Lock can't be "
+                           "acquired before being released")


### PR DESCRIPTION
Migrate TC [test_verify_rebalance_with_locks_on_files.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/dht/test_verify_rebalance_with_locks_on_files.py)

Updates: #292
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>