### PR TITLE
Migrated TC test_copy_dir_subvol_down

### DIFF
--- a/tests/functional/dht/test_copy_dir_subvol_down.py
+++ b/tests/functional/dht/test_copy_dir_subvol_down.py
@@ -1,75 +1,50 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.glusterdir import mkdir
-from glustolibs.io.utils import collect_mounts_arequal, validate_io_procs
-from glustolibs.misc.misc_libs import upload_scripts
-from glustolibs.gluster.dht_test_utils import (find_hashed_subvol,
-                                               find_new_hashed)
-from glustolibs.gluster.volume_libs import get_subvols
-from glustolibs.gluster.brick_libs import bring_bricks_offline
+"""
+ Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to check copy of a dir when a subvol is down
+"""
+
+# disruptive;dist,dist-rep,dist-arb,dist-disp
+from copy import deepcopy
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed', 'distributed-replicated',
-           'distributed-arbiter', 'distributed-dispersed'],
-          ['glusterfs']])
-class TestCopyDirSubvolDown(GlusterBaseClass):
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
+class TestCopyDirSubvolDown(DParentTest):
 
-        # Check for the default dist_count value and override it if required
-        if cls.default_volume_type_config['distributed']['dist_count'] <= 2:
-            cls.default_volume_type_config['distributed']['dist_count'] = 4
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
+        """
+        Override the volume create, start and mount in parent_run_test
+        """
+        conf_hash = deepcopy(self.vol_type_inf[self.volume_type])
+        if self.volume_type == "dist":
+            conf_hash['dist_count'] = 4
         else:
-            cls.default_volume_type_config[cls.voltype]['dist_count'] = 3
-
-        # Upload io scripts for running IO on mounts
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts "
-                                 "to clients %s" % cls.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   cls.clients)
-
-    def setUp(self):
-
-        # Calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        # Setup Volume and Mount Volume
-        ret = self.setup_volume_and_mount_volume([self.mounts[0]])
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
-        g.log.info("Successful in Setup Volume and Mount Volume")
-
-    def tearDown(self):
-
-        # Unmount and cleanup original volume
-        ret = self.unmount_volume_and_cleanup_volume(mounts=[self.mounts[0]])
-        if not ret:
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+            conf_hash['dist_count'] = 3
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        self.redant.execute_abstract_op_node(f"mkdir -p "
+                                             f"{self.mountpoint}",
+                                             self.client_list[0])
+        self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                 self.mountpoint, self.client_list[0])
 
     def _create_src(self, m_point):
         """
@@ -77,23 +52,18 @@ class TestCopyDirSubvolDown(GlusterBaseClass):
         source directory.
         """
         # Create source dir
-        ret = mkdir(self.mounts[0].client_system, "{}/src_dir".format(m_point))
-        self.assertTrue(ret, "mkdir of src_dir failed")
+        self.redant.execute_abstract_op_node(m_point, "src_dir",
+                                             self.client_list[0])
 
         # Create files inside source dir
-        cmd = ("/usr/bin/env python %s create_files "
-               "-f 100 %s/src_dir/" % (
-                   self.script_upload_path, m_point))
-        proc = g.run_async(self.mounts[0].client_system,
-                           cmd, user=self.mounts[0].user)
-        g.log.info("IO on %s:%s is started successfully",
-                   self.mounts[0].client_system, m_point)
-
-        # Validate IO
-        self.assertTrue(
-            validate_io_procs([proc], self.mounts[0]),
-            "IO failed on some of the clients"
-        )
+        proc = self.redant.create_files("1k", f"{m_point}/src_dir/",
+                                        self.client_list[0], 100)
+        mounts = {
+            "client": self.client_list[0],
+            "mountpath": self.mountpoint
+        }
+        if not self.redant.validate_io_procs(proc, mounts):
+            raise Exception("IO failed on the client")
 
     def _copy_files_check_contents(self, m_point, dest_dir):
         """
@@ -101,50 +71,41 @@ class TestCopyDirSubvolDown(GlusterBaseClass):
         directory when it hashes to up-subvol and check
         if all the files are copied properly.
         """
-        # pylint: disable=protected-access
+        mounts = {
+            "client": self.client_list[0],
+            "mountpath": m_point
+        }
         # collect arequal checksum on src dir
-        ret, src_checksum = collect_mounts_arequal(
-            self.mounts[0], '{}/src_dir'.format(m_point))
-        self.assertTrue(ret, ("Failed to get arequal on client"
-                              " {}".format(self.clients[0])))
+        src_checksum = self.redant.collect_mounts_arequal(mounts, "src_dir")
 
         # copy src_dir to dest_dir
-        command = "cd {}; cp -r  src_dir {}".format(m_point, dest_dir)
-        ret, _, _ = g.run(self.mounts[0].client_system, command)
-        self.assertEqual(ret, 0, "Failed to copy of src dir to"
-                                 " dest dir")
-        g.log.info("Successfully copied src dir to dest dir.")
+        cmd = f"cd {m_point}; cp -r src_dir {dest_dir}"
+        self.redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # collect arequal checksum on destination dir
-        ret, dest_checksum = collect_mounts_arequal(
-            self.mounts[0], '{}/{}'.format(m_point, dest_dir))
-        self.assertTrue(ret, ("Failed to get arequal on client"
-                              " {}".format(self.mounts[0])))
+        dest_checksum = self.redant.collect_mounts_arequal(mounts, dest_dir)
 
         # Check if the contents of src dir are copied to
         # dest dir
-        self.assertEqual(src_checksum,
-                         dest_checksum,
-                         'All the contents of src dir are not'
-                         ' copied to dest dir')
-        g.log.info('Successfully copied the contents of src dir'
-                   ' to dest dir')
+        if src_checksum != dest_checksum:
+            raise Exception('All the contents of src dir are not'
+                            ' copied to dest dir')
 
     def _copy_when_dest_hash_down(self, m_point, dest_dir):
         """
         Copy files from source directory to destination
         directory when it hashes to down-subvol.
         """
-        # pylint: disable=protected-access
         # copy src_dir to dest_dir (should fail as hash subvol for dest
         # dir is down)
-        command = "cd {}; cp -r  src_dir {}".format(m_point, dest_dir)
-        ret, _, _ = g.run(self.mounts[0].client_system, command)
-        self.assertEqual(ret, 1, "Unexpected : Copy of src dir to"
-                                 " dest dir passed")
-        g.log.info("Copy of src dir to dest dir failed as expected.")
+        cmd = f"cd {m_point}; cp -r src_dir {dest_dir}"
+        ret = self.redant.execute_abstract_op_node(cmd, self.client_list[0],
+                                                   False)
+        if ret['error_code'] == 0:
+            raise Exception("Unexpected : Copy of src dir to"
+                            " dest dir passed")
 
-    def test_copy_existing_dir_dest_subvol_down(self):
+    def run_test(self, redant):
         """
         Case 1:
         - Create directory from mount point.
@@ -152,63 +113,66 @@ class TestCopyDirSubvolDown(GlusterBaseClass):
           directory hashes to down sub-volume.
         - Copy directory and make sure destination dir does not exist
         """
-        # pylint: disable=protected-access
-        m_point = self.mounts[0].mountpoint
-
         # Create source dir
-        ret = mkdir(self.mounts[0].client_system, "{}/src_dir".format(m_point))
-        self.assertTrue(ret, "mkdir of src_dir failed")
-        g.log.info("Directory src_dir created successfully")
+        redant.create_dir(self.mountpoint, "src_dir", self.client_list[0])
 
         # Get subvol list
-        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
-        self.assertIsNotNone(subvols, "Failed to get subvols")
+        subvols = redant.get_subvols(self.vol_name, self.server_list[0])
+        if not subvols:
+            raise Exception("Failed to get subvols")
 
         # Find out the destination dir name such that it hashes to
         # different subvol
-        newdir = find_new_hashed(subvols, "/", "src_dir")
-        dest_dir = str(newdir.newname)
-        dest_count = newdir.subvol_count
+        newdir = redant.find_new_hashed(subvols, "", "src_dir")
+        if not newdir:
+            raise Exception("Failed to get new hashed subvol")
+        dest_dir = str(newdir[0])
+        dest_count = newdir[2]
 
         # Kill the brick/subvol to which the destination dir hashes
-        ret = bring_bricks_offline(
-            self.volname, subvols[dest_count])
-        self.assertTrue(ret, ('Error in bringing down subvolume %s',
-                              subvols[dest_count]))
-        g.log.info('DHT subvol %s is offline', subvols[dest_count])
+        ret = redant.bring_bricks_offline(self.vol_name, subvols[dest_count])
+        if not ret:
+            raise Exception("Error in bringing down subvolume "
+                            f"{subvols[dest_count]}")
 
         # Copy src_dir to dest_dir (should fail as hash subvol for dest
         # dir is down)
-        self._copy_when_dest_hash_down(m_point, dest_dir)
+        self._copy_when_dest_hash_down(self.mountpoint, dest_dir)
 
-    def test_copy_existing_dir_dest_subvol_up(self):
+        # Cleanup mount and force start volume for next case
+        redant.volume_start(self.vol_name, self.server_list[0], force=True)
+
+        cmd = f"rm -rf {self.mountpoint}/*"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
+
+        # Case 2: test_copy_existing_dir_dest_subvol_up
         """
-        Case 2:
         - Create files and directories from mount point.
         - Copy dir ---> Bring down dht sub-volume where destination
           directory should not hash to down sub-volume
         - copy dir and make sure destination dir does not exist
         """
-        # pylint: disable=protected-access
-        m_point = self.mounts[0].mountpoint
-
         # Create source dir and create files inside it
-        self._create_src(m_point)
+        self._create_src(self.mountpoint)
 
         # Get subvol list
-        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
-        self.assertIsNotNone(subvols, "Failed to get subvols")
+        subvols = redant.get_subvols(self.vol_name, self.server_list[0])
+        if not subvols:
+            raise Exception("Failed to get subvols")
 
         # Find out hashed brick/subvol for src dir
-        src_subvol, src_count = find_hashed_subvol(subvols, "/", "src_dir")
-        self.assertIsNotNone(src_subvol, "Could not find srchashed")
-        g.log.info("Hashed subvol for src_dir is %s", src_subvol._path)
+        src_hashed = redant.find_hashed_subvol(subvols, "", "src_dir")
+        if not src_hashed:
+            raise Exception("Could not find srchashed")
+        src_subvol, src_count = src_hashed
 
         # Find out the destination dir name such that it hashes to
         # different subvol
-        newdir = find_new_hashed(subvols, "/", "src_dir")
-        dest_dir = str(newdir.newname)
-        dest_count = newdir.subvol_count
+        newdir = redant.find_new_hashed(subvols, "", "src_dir")
+        if not newdir:
+            raise Exception("Failed to get new hashed subvol")
+        dest_dir = str(newdir[0])
+        dest_count = newdir[2]
 
         # Remove the hashed subvol for dest and src dir from the
         # subvol list
@@ -216,42 +180,45 @@ class TestCopyDirSubvolDown(GlusterBaseClass):
             subvols.remove(item)
 
         # Bring down a DHT subvol
-        ret = bring_bricks_offline(self.volname, subvols[0])
-        self.assertTrue(ret, ('Error in bringing down subvolume %s',
-                              subvols[0]))
-        g.log.info('DHT subvol %s is offline', subvols[0])
+        ret = redant.bring_bricks_offline(self.vol_name, subvols[0])
+        if not ret:
+            raise Exception(f"Error in bringing down subvolume {subvols[0]}")
 
         # Create files on source dir and
         # perform copy of src_dir to dest_dir
-        self._copy_files_check_contents(m_point, dest_dir)
+        self._copy_files_check_contents(self.mountpoint, dest_dir)
 
-    def test_copy_new_dir_dest_subvol_up(self):
+        # Cleanup mount and force start volume for next case
+        redant.volume_start(self.vol_name, self.server_list[0], force=True)
+
+        cmd = f"rm -rf {self.mountpoint}/*"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
+
+        # Case 3: test_copy_new_dir_dest_subvol_up
         """
-        Case 3:
         - Copy dir ---> Bring down dht sub-volume where destination
           directory should not hash to down sub-volume
         - Create files and directories from mount point.
         - copy dir and make sure destination dir does not exist
         """
-        # pylint: disable=protected-access
-        # pylint: disable=too-many-statements
-        m_point = self.mounts[0].mountpoint
-
         # Get subvols
-        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
-        self.assertIsNotNone(subvols, "Failed to get subvols")
+        subvols = redant.get_subvols(self.vol_name, self.server_list[0])
+        if not subvols:
+            raise Exception("Failed to get subvols")
 
         # Find out hashed brick/subvol for src dir
-        src_subvol, src_count = find_hashed_subvol(
-            subvols, "/", "src_dir")
-        self.assertIsNotNone(src_subvol, "Could not find srchashed")
-        g.log.info("Hashed subvol for src_dir is %s", src_subvol._path)
+        src_hashed = redant.find_hashed_subvol(subvols, "", "src_dir")
+        if not src_hashed:
+            raise Exception("Could not find srchashed")
+        src_subvol, src_count = src_hashed
 
         # Find out the destination dir name such that it hashes to
         # different subvol
-        newdir = find_new_hashed(subvols, "/", "src_dir")
-        dest_dir = str(newdir.newname)
-        dest_count = newdir.subvol_count
+        newdir = redant.find_new_hashed(subvols, "", "src_dir")
+        if not newdir:
+            raise Exception("Failed to get new hashed subvol")
+        dest_dir = str(newdir[0])
+        dest_count = newdir[2]
 
         # Remove the hashed subvol for dest and src dir from the
         # subvol list
@@ -259,50 +226,52 @@ class TestCopyDirSubvolDown(GlusterBaseClass):
             subvols.remove(item)
 
         # Bring down a dht subvol
-        ret = bring_bricks_offline(self.volname, subvols[0])
-        self.assertTrue(ret, ('Error in bringing down subvolume %s',
-                              subvols[0]))
-        g.log.info('DHT subvol %s is offline', subvols[0])
+        ret = redant.bring_bricks_offline(self.vol_name, subvols[0])
+        if not ret:
+            raise Exception(f"Error in bringing down subvolume {subvols[0]}")
 
         # Create source dir and create files inside it
-        self._create_src(m_point)
+        self._create_src(self.mountpoint)
 
         # Create files on source dir and
         # perform copy of src_dir to dest_dir
-        self._copy_files_check_contents(m_point, dest_dir)
+        self._copy_files_check_contents(self.mountpoint, dest_dir)
 
-    def test_copy_new_dir_dest_subvol_down(self):
+        # Cleanup mount and force start volume for next case
+        redant.volume_start(self.vol_name, self.server_list[0], force=True)
+
+        cmd = f"rm -rf {self.mountpoint}/*"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
+
+        # Case 4: test_copy_new_dir_dest_subvol_down
         """
-         Case 4:
         - Copy dir ---> Bring down dht sub-volume where destination
           directory hashes to down sub-volume
         - Create directory from mount point.
         - Copy dir and make sure destination dir does not exist
         """
-        # pylint: disable=protected-access
-        m_point = self.mounts[0].mountpoint
-
         # Get subvol list
-        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
-        self.assertIsNotNone(subvols, "Failed to get subvols")
+        subvols = redant.get_subvols(self.vol_name, self.server_list[0])
+        if not subvols:
+            raise Exception("Failed to get subvols")
 
         # Find out the destination dir name such that it hashes to
         # different subvol
-        newdir = find_new_hashed(subvols, "/", "src_dir")
-        dest_dir = str(newdir.newname)
-        dest_count = newdir.subvol_count
+        newdir = redant.find_new_hashed(subvols, "", "src_dir")
+        if not newdir:
+            raise Exception("Failed to get new hashed subvol")
+        dest_dir = str(newdir[0])
+        dest_count = newdir[2]
 
         # Bring down the hashed-subvol for dest dir
-        ret = bring_bricks_offline(self.volname, subvols[dest_count])
-        self.assertTrue(ret, ('Error in bringing down subvolume %s',
-                              subvols[dest_count]))
-        g.log.info('DHT subvol %s is offline', subvols[dest_count])
+        ret = redant.bring_bricks_offline(self.vol_name, subvols[dest_count])
+        if not ret:
+            raise Exception("Error in bringing down subvolume "
+                            f"{subvols[dest_count]}")
 
         # Create source dir
-        ret = mkdir(self.mounts[0].client_system, "{}/src_dir".format(m_point))
-        self.assertTrue(ret, "mkdir of src_dir failed")
-        g.log.info("Directory src_dir created successfully")
+        redant.create_dir(self.mountpoint, "src_dir", self.client_list[0])
 
         # Copy src_dir to dest_dir (should fail as hash subvol for dest
         # dir is down)
-        self._copy_when_dest_hash_down(m_point, dest_dir)
+        self._copy_when_dest_hash_down(self.mountpoint, dest_dir)

--- a/tests/functional/dht/test_copy_dir_subvol_down.py
+++ b/tests/functional/dht/test_copy_dir_subvol_down.py
@@ -21,6 +21,7 @@
 
 # disruptive;dist,dist-rep,dist-arb,dist-disp
 from copy import deepcopy
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -52,8 +53,7 @@ class TestCopyDirSubvolDown(DParentTest):
         source directory.
         """
         # Create source dir
-        self.redant.execute_abstract_op_node(m_point, "src_dir",
-                                             self.client_list[0])
+        self.redant.create_dir(m_point, "src_dir", self.client_list[0])
 
         # Create files inside source dir
         proc = self.redant.create_files("1k", f"{m_point}/src_dir/",
@@ -142,6 +142,9 @@ class TestCopyDirSubvolDown(DParentTest):
         # Cleanup mount and force start volume for next case
         redant.volume_start(self.vol_name, self.server_list[0], force=True)
 
+        # Add sleep to allow the clients to get back up
+        sleep(3)
+
         cmd = f"rm -rf {self.mountpoint}/*"
         redant.execute_abstract_op_node(cmd, self.client_list[0])
 
@@ -191,6 +194,9 @@ class TestCopyDirSubvolDown(DParentTest):
         # Cleanup mount and force start volume for next case
         redant.volume_start(self.vol_name, self.server_list[0], force=True)
 
+        # Add sleep to allow the clients to get back up
+        sleep(3)
+
         cmd = f"rm -rf {self.mountpoint}/*"
         redant.execute_abstract_op_node(cmd, self.client_list[0])
 
@@ -239,6 +245,9 @@ class TestCopyDirSubvolDown(DParentTest):
 
         # Cleanup mount and force start volume for next case
         redant.volume_start(self.vol_name, self.server_list[0], force=True)
+
+        # Add sleep to allow the clients to get back up
+        sleep(3)
 
         cmd = f"rm -rf {self.mountpoint}/*"
         redant.execute_abstract_op_node(cmd, self.client_list[0])

--- a/tests/functional/dht/test_copy_dir_subvol_down.py
+++ b/tests/functional/dht/test_copy_dir_subvol_down.py
@@ -1,0 +1,308 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.glusterdir import mkdir
+from glustolibs.io.utils import collect_mounts_arequal, validate_io_procs
+from glustolibs.misc.misc_libs import upload_scripts
+from glustolibs.gluster.dht_test_utils import (find_hashed_subvol,
+                                               find_new_hashed)
+from glustolibs.gluster.volume_libs import get_subvols
+from glustolibs.gluster.brick_libs import bring_bricks_offline
+
+
+@runs_on([['distributed', 'distributed-replicated',
+           'distributed-arbiter', 'distributed-dispersed'],
+          ['glusterfs']])
+class TestCopyDirSubvolDown(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        cls.get_super_method(cls, 'setUpClass')()
+
+        # Check for the default dist_count value and override it if required
+        if cls.default_volume_type_config['distributed']['dist_count'] <= 2:
+            cls.default_volume_type_config['distributed']['dist_count'] = 4
+        else:
+            cls.default_volume_type_config[cls.voltype]['dist_count'] = 3
+
+        # Upload io scripts for running IO on mounts
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts "
+                                 "to clients %s" % cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+    def setUp(self):
+
+        # Calling GlusterBaseClass setUp
+        self.get_super_method(self, 'setUp')()
+
+        # Setup Volume and Mount Volume
+        ret = self.setup_volume_and_mount_volume([self.mounts[0]])
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
+        g.log.info("Successful in Setup Volume and Mount Volume")
+
+    def tearDown(self):
+
+        # Unmount and cleanup original volume
+        ret = self.unmount_volume_and_cleanup_volume(mounts=[self.mounts[0]])
+        if not ret:
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()
+
+    def _create_src(self, m_point):
+        """
+        Create the source directory and files under the
+        source directory.
+        """
+        # Create source dir
+        ret = mkdir(self.mounts[0].client_system, "{}/src_dir".format(m_point))
+        self.assertTrue(ret, "mkdir of src_dir failed")
+
+        # Create files inside source dir
+        cmd = ("/usr/bin/env python %s create_files "
+               "-f 100 %s/src_dir/" % (
+                   self.script_upload_path, m_point))
+        proc = g.run_async(self.mounts[0].client_system,
+                           cmd, user=self.mounts[0].user)
+        g.log.info("IO on %s:%s is started successfully",
+                   self.mounts[0].client_system, m_point)
+
+        # Validate IO
+        self.assertTrue(
+            validate_io_procs([proc], self.mounts[0]),
+            "IO failed on some of the clients"
+        )
+
+    def _copy_files_check_contents(self, m_point, dest_dir):
+        """
+        Copy files from source directory to destination
+        directory when it hashes to up-subvol and check
+        if all the files are copied properly.
+        """
+        # pylint: disable=protected-access
+        # collect arequal checksum on src dir
+        ret, src_checksum = collect_mounts_arequal(
+            self.mounts[0], '{}/src_dir'.format(m_point))
+        self.assertTrue(ret, ("Failed to get arequal on client"
+                              " {}".format(self.clients[0])))
+
+        # copy src_dir to dest_dir
+        command = "cd {}; cp -r  src_dir {}".format(m_point, dest_dir)
+        ret, _, _ = g.run(self.mounts[0].client_system, command)
+        self.assertEqual(ret, 0, "Failed to copy of src dir to"
+                                 " dest dir")
+        g.log.info("Successfully copied src dir to dest dir.")
+
+        # collect arequal checksum on destination dir
+        ret, dest_checksum = collect_mounts_arequal(
+            self.mounts[0], '{}/{}'.format(m_point, dest_dir))
+        self.assertTrue(ret, ("Failed to get arequal on client"
+                              " {}".format(self.mounts[0])))
+
+        # Check if the contents of src dir are copied to
+        # dest dir
+        self.assertEqual(src_checksum,
+                         dest_checksum,
+                         'All the contents of src dir are not'
+                         ' copied to dest dir')
+        g.log.info('Successfully copied the contents of src dir'
+                   ' to dest dir')
+
+    def _copy_when_dest_hash_down(self, m_point, dest_dir):
+        """
+        Copy files from source directory to destination
+        directory when it hashes to down-subvol.
+        """
+        # pylint: disable=protected-access
+        # copy src_dir to dest_dir (should fail as hash subvol for dest
+        # dir is down)
+        command = "cd {}; cp -r  src_dir {}".format(m_point, dest_dir)
+        ret, _, _ = g.run(self.mounts[0].client_system, command)
+        self.assertEqual(ret, 1, "Unexpected : Copy of src dir to"
+                                 " dest dir passed")
+        g.log.info("Copy of src dir to dest dir failed as expected.")
+
+    def test_copy_existing_dir_dest_subvol_down(self):
+        """
+        Case 1:
+        - Create directory from mount point.
+        - Copy dir ---> Bring down dht sub-volume where destination
+          directory hashes to down sub-volume.
+        - Copy directory and make sure destination dir does not exist
+        """
+        # pylint: disable=protected-access
+        m_point = self.mounts[0].mountpoint
+
+        # Create source dir
+        ret = mkdir(self.mounts[0].client_system, "{}/src_dir".format(m_point))
+        self.assertTrue(ret, "mkdir of src_dir failed")
+        g.log.info("Directory src_dir created successfully")
+
+        # Get subvol list
+        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
+        self.assertIsNotNone(subvols, "Failed to get subvols")
+
+        # Find out the destination dir name such that it hashes to
+        # different subvol
+        newdir = find_new_hashed(subvols, "/", "src_dir")
+        dest_dir = str(newdir.newname)
+        dest_count = newdir.subvol_count
+
+        # Kill the brick/subvol to which the destination dir hashes
+        ret = bring_bricks_offline(
+            self.volname, subvols[dest_count])
+        self.assertTrue(ret, ('Error in bringing down subvolume %s',
+                              subvols[dest_count]))
+        g.log.info('DHT subvol %s is offline', subvols[dest_count])
+
+        # Copy src_dir to dest_dir (should fail as hash subvol for dest
+        # dir is down)
+        self._copy_when_dest_hash_down(m_point, dest_dir)
+
+    def test_copy_existing_dir_dest_subvol_up(self):
+        """
+        Case 2:
+        - Create files and directories from mount point.
+        - Copy dir ---> Bring down dht sub-volume where destination
+          directory should not hash to down sub-volume
+        - copy dir and make sure destination dir does not exist
+        """
+        # pylint: disable=protected-access
+        m_point = self.mounts[0].mountpoint
+
+        # Create source dir and create files inside it
+        self._create_src(m_point)
+
+        # Get subvol list
+        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
+        self.assertIsNotNone(subvols, "Failed to get subvols")
+
+        # Find out hashed brick/subvol for src dir
+        src_subvol, src_count = find_hashed_subvol(subvols, "/", "src_dir")
+        self.assertIsNotNone(src_subvol, "Could not find srchashed")
+        g.log.info("Hashed subvol for src_dir is %s", src_subvol._path)
+
+        # Find out the destination dir name such that it hashes to
+        # different subvol
+        newdir = find_new_hashed(subvols, "/", "src_dir")
+        dest_dir = str(newdir.newname)
+        dest_count = newdir.subvol_count
+
+        # Remove the hashed subvol for dest and src dir from the
+        # subvol list
+        for item in (subvols[src_count], subvols[dest_count]):
+            subvols.remove(item)
+
+        # Bring down a DHT subvol
+        ret = bring_bricks_offline(self.volname, subvols[0])
+        self.assertTrue(ret, ('Error in bringing down subvolume %s',
+                              subvols[0]))
+        g.log.info('DHT subvol %s is offline', subvols[0])
+
+        # Create files on source dir and
+        # perform copy of src_dir to dest_dir
+        self._copy_files_check_contents(m_point, dest_dir)
+
+    def test_copy_new_dir_dest_subvol_up(self):
+        """
+        Case 3:
+        - Copy dir ---> Bring down dht sub-volume where destination
+          directory should not hash to down sub-volume
+        - Create files and directories from mount point.
+        - copy dir and make sure destination dir does not exist
+        """
+        # pylint: disable=protected-access
+        # pylint: disable=too-many-statements
+        m_point = self.mounts[0].mountpoint
+
+        # Get subvols
+        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
+        self.assertIsNotNone(subvols, "Failed to get subvols")
+
+        # Find out hashed brick/subvol for src dir
+        src_subvol, src_count = find_hashed_subvol(
+            subvols, "/", "src_dir")
+        self.assertIsNotNone(src_subvol, "Could not find srchashed")
+        g.log.info("Hashed subvol for src_dir is %s", src_subvol._path)
+
+        # Find out the destination dir name such that it hashes to
+        # different subvol
+        newdir = find_new_hashed(subvols, "/", "src_dir")
+        dest_dir = str(newdir.newname)
+        dest_count = newdir.subvol_count
+
+        # Remove the hashed subvol for dest and src dir from the
+        # subvol list
+        for item in (subvols[src_count], subvols[dest_count]):
+            subvols.remove(item)
+
+        # Bring down a dht subvol
+        ret = bring_bricks_offline(self.volname, subvols[0])
+        self.assertTrue(ret, ('Error in bringing down subvolume %s',
+                              subvols[0]))
+        g.log.info('DHT subvol %s is offline', subvols[0])
+
+        # Create source dir and create files inside it
+        self._create_src(m_point)
+
+        # Create files on source dir and
+        # perform copy of src_dir to dest_dir
+        self._copy_files_check_contents(m_point, dest_dir)
+
+    def test_copy_new_dir_dest_subvol_down(self):
+        """
+         Case 4:
+        - Copy dir ---> Bring down dht sub-volume where destination
+          directory hashes to down sub-volume
+        - Create directory from mount point.
+        - Copy dir and make sure destination dir does not exist
+        """
+        # pylint: disable=protected-access
+        m_point = self.mounts[0].mountpoint
+
+        # Get subvol list
+        subvols = (get_subvols(self.mnode, self.volname))['volume_subvols']
+        self.assertIsNotNone(subvols, "Failed to get subvols")
+
+        # Find out the destination dir name such that it hashes to
+        # different subvol
+        newdir = find_new_hashed(subvols, "/", "src_dir")
+        dest_dir = str(newdir.newname)
+        dest_count = newdir.subvol_count
+
+        # Bring down the hashed-subvol for dest dir
+        ret = bring_bricks_offline(self.volname, subvols[dest_count])
+        self.assertTrue(ret, ('Error in bringing down subvolume %s',
+                              subvols[dest_count]))
+        g.log.info('DHT subvol %s is offline', subvols[dest_count])
+
+        # Create source dir
+        ret = mkdir(self.mounts[0].client_system, "{}/src_dir".format(m_point))
+        self.assertTrue(ret, "mkdir of src_dir failed")
+        g.log.info("Directory src_dir created successfully")
+
+        # Copy src_dir to dest_dir (should fail as hash subvol for dest
+        # dir is down)
+        self._copy_when_dest_hash_down(m_point, dest_dir)


### PR DESCRIPTION
Migrated TC [test_copy_dir_subvol_down](https://github.com/gluster/glusto-tests/blob/master/tests/functional/dht/test_copy_dir_subvol_down.py)

Updates: #292
Signed-off-by: nik-redhat <nladha@redhat.com>