### PR TITLE
Migrated TC test_healing_of_custom_xattrs_on_newly_added_bricks

### DIFF
--- a/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py
+++ b/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py
@@ -1,0 +1,172 @@
+#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# pylint: disable=too-many-statements, undefined-loop-variable
+# pylint: disable=too-many-branches,too-many-locals,pointless-string-statement
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.brick_libs import get_all_bricks
+from glustolibs.gluster.dht_test_utils import validate_files_in_dir
+import glustolibs.gluster.constants as k
+from glustolibs.gluster.glusterfile import get_fattr
+from glustolibs.gluster.glusterdir import get_dir_contents
+from glustolibs.gluster.rebalance_ops import (
+    wait_for_rebalance_to_complete, rebalance_start)
+from glustolibs.gluster.volume_libs import expand_volume
+from glustolibs.gluster.heal_libs import monitor_heal_completion
+
+
+@runs_on([['distributed-replicated',
+           'distributed-dispersed',
+           'distributed-arbiter'],
+          ['glusterfs']])
+class TestCustomxattrsOnNewBricks(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+
+        # Calling GlusterBaseClass setUpClass
+        cls.get_super_method(cls, 'setUpClass')()
+
+        # Setup Volume and Mount Volume
+        g.log.info("Starting to Setup Volume and Mount Volume")
+        ret = cls.setup_volume_and_mount_volume(mounts=cls.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
+        g.log.info("Successful in Setup Volume and Mount Volume")
+
+    @classmethod
+    def tearDownClass(cls):
+        # Unmount Volume and Cleanup Volume
+        g.log.info("Starting to Unmount Volume and Cleanup Volume")
+        ret = cls.unmount_volume_and_cleanup_volume(mounts=cls.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Unmount Volume and Cleanup Volume")
+        g.log.info("Successful in Unmount Volume and Cleanup Volume")
+
+        # Calling GlusterBaseClass tearDown
+        cls.get_super_method(cls, 'tearDownClass')()
+
+    def check_xattr(self, list_of_all_dirs):
+        """
+        Check the custom xattr on backend bricks for the directories.
+
+        Args:
+        list_of_all_dirs(list): List of dirs created on mount.
+
+        Returns:
+        Success/failure msg.
+        """
+        for direc in list_of_all_dirs:
+            for brick in get_all_bricks(self.mnode, self.volname):
+                host, brick_path = brick.split(':')
+                brick_dir_path = brick_path + '/' + direc
+                ret = get_fattr(host, brick_dir_path, 'user.foo')
+                self.assertIsNotNone(ret, "Custom xattr is not displayed on"
+                                     " the backend bricks ")
+                g.log.info("Custom xattr %s is displayed on the back-end"
+                           " bricks", ret)
+
+    def test_healing_of_custom_xattrs_on_newly_added_bricks(self):
+        """
+        Description: Tests to check that the custom xattrs are healed on the
+                     dirs when new bricks are added
+        Steps :
+        1) Create a volume.
+        2) Mount the volume using FUSE.
+        3) Create 100 directories on the mount point.
+        4) Set the xattr on the directories.
+        5) Add bricks to the volume and trigger rebalance.
+        6) Check if all the bricks have healed.
+        7) After rebalance completes, check the xattr for dirs on the newly
+           added bricks.
+        """
+        # pylint: disable=too-many-function-args
+
+        # Creating 1000 directories on volume root
+        m_point = self.mounts[0].mountpoint
+        command = 'mkdir -p ' + m_point + '/dir{1..100}'
+        ret, _, _ = g.run(self.mounts[0].client_system, command)
+        self.assertEqual(ret, 0, ("Directory creation failed on %s",
+                                  self.mounts[0].mountpoint))
+        g.log.info("Directories created successfully.")
+
+        # Lookup on the mount point
+        command = 'ls ' + m_point + '/'
+        ret, _, _ = g.run(self.mounts[0].client_system, command)
+        self.assertEqual(ret, 0, "ls failed on parent directory")
+        g.log.info("ls on parent directory: successful")
+
+        # Setting up the custom xattr for all the directories on mount point
+        m_point = self.mounts[0].mountpoint
+        command = 'setfattr -n user.foo -v "foobar" ' + m_point + '/dir*'
+        ret, _, _ = g.run(self.mounts[0].client_system, command)
+        self.assertEqual(ret, 0, "Failed to set the xattr on the"
+                         " directories")
+        g.log.info("Successfully set custom xattr on the directories")
+
+        # Checking the layout of the directories on the back-end
+        flag = validate_files_in_dir(self.clients[0],
+                                     m_point,
+                                     test_type=k.TEST_LAYOUT_IS_COMPLETE)
+        self.assertTrue(flag, "Layout has some holes or overlaps")
+        g.log.info("Layout is completely set")
+
+        # Creating a list of directories on the mount point
+        list_of_all_dirs = get_dir_contents(self.mounts[0].client_system,
+                                            m_point)
+        self.assertNotEqual(list_of_all_dirs, None, "Creation of directory"
+                            " list failed.")
+        g.log.info("Creation of directory list is successful.")
+
+        # Checking the custom xattr on backend bricks for the directories
+        self.check_xattr(list_of_all_dirs)
+
+        # Expanding volume by adding bricks to the volume
+        ret = expand_volume(self.mnode, self.volname, self.servers,
+                            self.all_servers_info)
+        self.assertTrue(ret, ("Volume %s: Expand failed", self.volname))
+        g.log.info("Volume %s: Expand success", self.volname)
+
+        # Start Rebalance
+        ret, _, _ = rebalance_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, ("Volume %s: Failed to start rebalance",
+                                  self.volname))
+        g.log.info("Volume %s: Rebalance start success", self.volname)
+
+        # Wait for rebalance to complete
+        ret = wait_for_rebalance_to_complete(self.mnode, self.volname)
+        self.assertTrue(ret, ("Volume %s: Rebalance failed to complete",
+                              self.volname))
+        g.log.info("Volume %s: Rebalance is completed", self.volname)
+
+        # Lookup on the mount point
+        command = 'ls -laR ' + m_point + '/'
+        ret, _, _ = g.run(self.mounts[0].client_system, command)
+        self.assertEqual(ret, 0, "ls failed on parent directory")
+        g.log.info("ls on parent directory: successful")
+
+        # Check if all the bricks are healed
+        ret = monitor_heal_completion(self.mnode, self.volname,
+                                      timeout_period=900)
+        self.assertTrue(ret, ("Heal is not complete for all bricks"))
+        g.log.info("Healing is complete for all the bricks")
+
+        # Checking the custom xattrs for all the directories on
+        # back end bricks after rebalance is complete
+        self.check_xattr(list_of_all_dirs)

--- a/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py
+++ b/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py
@@ -50,17 +50,17 @@ class TestCustomxattrsOnNewBricks(GlusterBaseClass):
             raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
         g.log.info("Successful in Setup Volume and Mount Volume")
 
-    @classmethod
-    def tearDownClass(cls):
-        # Unmount Volume and Cleanup Volume
+    def tearDown(self):
+
+        # Unmount and cleanup original volume
         g.log.info("Starting to Unmount Volume and Cleanup Volume")
-        ret = cls.unmount_volume_and_cleanup_volume(mounts=cls.mounts)
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
         if not ret:
-            raise ExecutionError("Failed to Unmount Volume and Cleanup Volume")
-        g.log.info("Successful in Unmount Volume and Cleanup Volume")
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+        g.log.info("Successful in umounting the volume and Cleanup")
 
         # Calling GlusterBaseClass tearDown
-        cls.get_super_method(cls, 'tearDownClass')()
+        self.get_super_method(self, 'tearDown')()
 
     def check_xattr(self, list_of_all_dirs):
         """

--- a/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py
+++ b/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py
@@ -1,91 +1,49 @@
-#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
 
-# pylint: disable=too-many-statements, undefined-loop-variable
-# pylint: disable=too-many-branches,too-many-locals,pointless-string-statement
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.brick_libs import get_all_bricks
-from glustolibs.gluster.dht_test_utils import validate_files_in_dir
-import glustolibs.gluster.constants as k
-from glustolibs.gluster.glusterfile import get_fattr
-from glustolibs.gluster.glusterdir import get_dir_contents
-from glustolibs.gluster.rebalance_ops import (
-    wait_for_rebalance_to_complete, rebalance_start)
-from glustolibs.gluster.volume_libs import expand_volume
-from glustolibs.gluster.heal_libs import monitor_heal_completion
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to check that the custom xattrs are healed on the
+    dirs when new bricks are added
+"""
+
+# disruptive;dist-rep,dist-disp,dist-arb
+from common.ops.gluster_ops.constants import TEST_LAYOUT_IS_COMPLETE
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed-replicated',
-           'distributed-dispersed',
-           'distributed-arbiter'],
-          ['glusterfs']])
-class TestCustomxattrsOnNewBricks(GlusterBaseClass):
+class TestCustomxattrsOnNewBricks(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-
-        # Calling GlusterBaseClass setUpClass
-        cls.get_super_method(cls, 'setUpClass')()
-
-        # Setup Volume and Mount Volume
-        g.log.info("Starting to Setup Volume and Mount Volume")
-        ret = cls.setup_volume_and_mount_volume(mounts=cls.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
-        g.log.info("Successful in Setup Volume and Mount Volume")
-
-    def tearDown(self):
-
-        # Unmount and cleanup original volume
-        g.log.info("Starting to Unmount Volume and Cleanup Volume")
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-        g.log.info("Successful in umounting the volume and Cleanup")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def check_xattr(self, list_of_all_dirs):
+    def _check_xattr(self, list_of_all_dirs):
         """
         Check the custom xattr on backend bricks for the directories.
-
-        Args:
-        list_of_all_dirs(list): List of dirs created on mount.
-
-        Returns:
-        Success/failure msg.
         """
+        brick_list = self.redant.get_all_bricks(self.vol_name,
+                                                self.server_list[0])
+        if not brick_list:
+            raise Exception("Failed to get brick list")
+
         for direc in list_of_all_dirs:
-            for brick in get_all_bricks(self.mnode, self.volname):
+            for brick in brick_list:
                 host, brick_path = brick.split(':')
-                brick_dir_path = brick_path + '/' + direc
-                ret = get_fattr(host, brick_dir_path, 'user.foo')
-                self.assertIsNotNone(ret, "Custom xattr is not displayed on"
-                                     " the backend bricks ")
-                g.log.info("Custom xattr %s is displayed on the back-end"
-                           " bricks", ret)
+                brick_dir_path = f"{brick_path}/{direc}"
+                self.redant.get_fattr(brick_dir_path, 'user.foo', host)
 
-    def test_healing_of_custom_xattrs_on_newly_added_bricks(self):
+    def run_test(self, redant):
         """
-        Description: Tests to check that the custom xattrs are healed on the
-                     dirs when new bricks are added
         Steps :
         1) Create a volume.
         2) Mount the volume using FUSE.
@@ -96,77 +54,62 @@ class TestCustomxattrsOnNewBricks(GlusterBaseClass):
         7) After rebalance completes, check the xattr for dirs on the newly
            added bricks.
         """
-        # pylint: disable=too-many-function-args
-
         # Creating 1000 directories on volume root
-        m_point = self.mounts[0].mountpoint
-        command = 'mkdir -p ' + m_point + '/dir{1..100}'
-        ret, _, _ = g.run(self.mounts[0].client_system, command)
-        self.assertEqual(ret, 0, ("Directory creation failed on %s",
-                                  self.mounts[0].mountpoint))
-        g.log.info("Directories created successfully.")
+        redant.create_dir(self.mountpoint, "dir{1..100}", self.client_list[0])
 
         # Lookup on the mount point
-        command = 'ls ' + m_point + '/'
-        ret, _, _ = g.run(self.mounts[0].client_system, command)
-        self.assertEqual(ret, 0, "ls failed on parent directory")
-        g.log.info("ls on parent directory: successful")
+        cmd = f'ls {self.mountpoint}/'
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Setting up the custom xattr for all the directories on mount point
-        m_point = self.mounts[0].mountpoint
-        command = 'setfattr -n user.foo -v "foobar" ' + m_point + '/dir*'
-        ret, _, _ = g.run(self.mounts[0].client_system, command)
-        self.assertEqual(ret, 0, "Failed to set the xattr on the"
-                         " directories")
-        g.log.info("Successfully set custom xattr on the directories")
+        cmd = f'setfattr -n user.foo -v "foobar" {self.mountpoint}/dir*'
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Checking the layout of the directories on the back-end
-        flag = validate_files_in_dir(self.clients[0],
-                                     m_point,
-                                     test_type=k.TEST_LAYOUT_IS_COMPLETE)
-        self.assertTrue(flag, "Layout has some holes or overlaps")
-        g.log.info("Layout is completely set")
+        flag = redant.validate_files_in_dir(self.client_list[0],
+                                            self.mountpoint,
+                                            test_type=TEST_LAYOUT_IS_COMPLETE)
+        if not flag:
+            raise Exception("Layout has some holes or overlaps")
 
         # Creating a list of directories on the mount point
-        list_of_all_dirs = get_dir_contents(self.mounts[0].client_system,
-                                            m_point)
-        self.assertNotEqual(list_of_all_dirs, None, "Creation of directory"
-                            " list failed.")
-        g.log.info("Creation of directory list is successful.")
+        list_of_all_dirs = redant.get_dir_contents(self.mountpoint,
+                                                   self.client_list[0])
+        if not list_of_all_dirs:
+            raise Exception("Creation of directory list failed.")
 
         # Checking the custom xattr on backend bricks for the directories
-        self.check_xattr(list_of_all_dirs)
+        self._check_xattr(list_of_all_dirs)
 
         # Expanding volume by adding bricks to the volume
-        ret = expand_volume(self.mnode, self.volname, self.servers,
-                            self.all_servers_info)
-        self.assertTrue(ret, ("Volume %s: Expand failed", self.volname))
-        g.log.info("Volume %s: Expand success", self.volname)
+        force = False
+        if self.volume_type == "dist-disp":
+            force = True
+        ret = redant.expand_volume(self.server_list[0], self.vol_name,
+                                   self.server_list, self.brick_roots, force)
+        if not ret:
+            raise Exception("Volume expand failed")
 
         # Start Rebalance
-        ret, _, _ = rebalance_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, ("Volume %s: Failed to start rebalance",
-                                  self.volname))
-        g.log.info("Volume %s: Rebalance start success", self.volname)
+        redant.rebalance_start(self.vol_name, self.server_list[0])
 
         # Wait for rebalance to complete
-        ret = wait_for_rebalance_to_complete(self.mnode, self.volname)
-        self.assertTrue(ret, ("Volume %s: Rebalance failed to complete",
-                              self.volname))
-        g.log.info("Volume %s: Rebalance is completed", self.volname)
+        ret = redant.wait_for_rebalance_to_complete(self.vol_name,
+                                                    self.server_list[0])
+        if not ret:
+            raise Exception(f"Volume {self.vol_name}: Rebalance failed "
+                            "to complete")
 
         # Lookup on the mount point
-        command = 'ls -laR ' + m_point + '/'
-        ret, _, _ = g.run(self.mounts[0].client_system, command)
-        self.assertEqual(ret, 0, "ls failed on parent directory")
-        g.log.info("ls on parent directory: successful")
+        cmd = f'ls -laR {self.mountpoint}/'
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Check if all the bricks are healed
-        ret = monitor_heal_completion(self.mnode, self.volname,
-                                      timeout_period=900)
-        self.assertTrue(ret, ("Heal is not complete for all bricks"))
-        g.log.info("Healing is complete for all the bricks")
+        if not redant.monitor_heal_completion(self.server_list[0],
+                                              self.vol_name,
+                                              timeout_period=900):
+            raise Exception("Heal not yet completed")
 
         # Checking the custom xattrs for all the directories on
         # back end bricks after rebalance is complete
-        self.check_xattr(list_of_all_dirs)
+        self._check_xattr(list_of_all_dirs)


### PR DESCRIPTION
Migrated TC [test_healing_of_custom_xattrs_on_newly_added_bricks](https://github.com/gluster/glusto-tests/blob/master/tests/functional/dht/test_healing_of_custom_xattrs_on_newly_added_bricks.py)

Updates: #292
Signed-off-by: nik-redhat <nladha@redhat.com>