### PR TITLE
[Common] Update hostnames to IP in DHT Ops

### DIFF
--- a/common/ops/gluster_ops/dht_ops.py
+++ b/common/ops/gluster_ops/dht_ops.py
@@ -7,6 +7,7 @@ hashing, layout and so on.
 
 import os
 import ctypes
+import socket
 import common.ops.gluster_ops.constants as c
 from common.ops.abstract_ops import AbstractOps
 
@@ -31,6 +32,7 @@ class DHTOps(AbstractOps):
         command = (f"getfattr -n trusted.glusterfs.dht -e hex {fqpath} "
                    "2> /dev/null | grep -i trusted.glusterfs.dht | "
                    "cut -d= -f2")
+        host = socket.gethostbyname(host)
         ret = self.execute_abstract_op_node(command, host, False)
         if ret['error_code'] != 0:
             self.logger.error("Failed to get the hash range for the brick."
@@ -74,6 +76,7 @@ class DHTOps(AbstractOps):
             None on fail.
         """
         host, _ = brickdir_path.split(':')
+        host = socket.gethostbyname(host)
         ver = self.get_gluster_version(host)
         ret = self.get_volume_type_from_brickpath(brickdir_path)
         if ret in ('Replicate', 'Disperse', 'Arbiter') and float(ver) >= 6.0:
@@ -230,6 +233,7 @@ class DHTOps(AbstractOps):
         except OSError:
             cmd = ("python3 /usr/share/redant/script/compute_hash.py "
                    f"{filename}")
+            host = socket.gethostbyname(host)
             ret = self.execute_abstract_op_node(cmd, host, False)
             if ret['error_code'] != 0:
                 self.logger.error(f"Unable to run the script on node: {host}")

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -6,7 +6,7 @@ from the test case.
 # pylint: disable=too-many-lines
 
 from time import sleep
-
+import socket
 from common.ops.abstract_ops import AbstractOps
 
 
@@ -979,6 +979,7 @@ class VolumeOps(AbstractOps):
         path_info = (brick_path_info[:-2] if brick_path_info.endswith("//")
                      else brick_path_info[:-1])
 
+        host = socket.gethostbyname(host)
         volume_list = self.get_volume_list(host)
         for volume in volume_list:
             brick_list = self.get_all_bricks(volume, host)


### PR DESCRIPTION
### Description:
Issue:
Sometimes, on using the hostnames fetched from xattr returns FQDNs/hostname instead of the IP of the node.
But, redant is configured to work only with IP addresses as a result the TCs failed in such scenarios.

Fix:
Added code to convert hostnames to IP in such functions which take the return values of xattrs and then execute the remote-executioner.

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
