### PR TITLE
Migrate TC test_rebalance_with_acl_set_to_files.py

### DIFF
--- a/common/ops/gluster_ops/mount_ops.py
+++ b/common/ops/gluster_ops/mount_ops.py
@@ -14,7 +14,8 @@ class MountOps(AbstractOps):
     """
 
     def volume_mount(self, server: str, volname: str,
-                     path: str, node: str = None, excep: bool = True):
+                     path: str, node: str = None, excep: bool = True,
+                     option: str = None):
         """
         Mounts the gluster volume to the client's filesystem.
         Args:
@@ -27,6 +28,7 @@ class MountOps(AbstractOps):
                           mount command fails. If set to False
                           the exception is bypassed and value from remote
                           executioner is returned. Defaults to True
+            option (str): command-line options specified  by the -o argument
 
         Returns:
             ret: A dictionary consisting
@@ -39,7 +41,10 @@ class MountOps(AbstractOps):
 
         """
 
-        cmd = f"mount.glusterfs {server}:/{volname} {path}"
+        if option:
+            cmd = f"mount -t glusterfs -o {option} {server}:/{volname} {path}"
+        else:
+            cmd = f"mount.glusterfs {server}:/{volname} {path}"
 
         ret = self.execute_abstract_op_node(cmd, node, excep)
         if not excep and ret['error_code'] != 0:

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -1654,3 +1654,48 @@ class IoOps(AbstractOps):
             return None
 
         return ret['msg'][0]
+
+    def set_acl(self, host, rule, fqpath):
+        """Set acl rule on a specific file
+
+        Args:
+            host (str): The hostname/ip of the remote system.
+            fqpath (str): The fully-qualified path to the file.
+            rule(str): The acl rule to be set on the file.
+
+        Returns:
+            (bool): True if command successful else False.
+        """
+        cmd = f"setfacl -m {rule} {fqpath}"
+        ret = self.execute_abstract_op_node(cmd, host, False)
+        if ret['error_code'] != 0:
+            self.logger.error(f"Failed to set acl rule on {fqpath}")
+            return False
+
+        return True
+
+    def get_acl(self, host, path, filename):
+        """Get all acl rules set to a file
+
+        Args:
+        host(str): Host on which the command is executed.
+        path (str): The fully-qualified path to the dir where file is present.
+        filename(str): Name of the file for which rules have to be fetched.
+
+        Returns:
+        (dict): A dictionary with the formatted output of the command.
+        (None): In case of failures
+
+        Example:
+        >>> get_acl('dhcp35-4.lab.eng.blr.redhat.com', '/root/', 'file')
+        ['# file: file1\n', '# owner: root\n', '# group: root\n',
+         'user::rw-\n', 'user:joker:rwx\n', 'group::r--\n',
+         'mask::rwx\n', 'other::r--\n', '\n']
+        """
+        cmd = f"cd {path};getfacl {filename}"
+        ret = self.execute_abstract_op_node(cmd, host, False)
+        if ret['error_code'] != 0:
+            self.logger.error(f"Failed to get acl {filename}")
+            return None
+
+        return ret

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -1655,7 +1655,7 @@ class IoOps(AbstractOps):
 
         return ret['msg'][0]
 
-    def set_acl(self, host, rule, fqpath):
+    def set_acl(self, host: str, rule: str, fqpath: str):
         """Set acl rule on a specific file
 
         Args:
@@ -1674,7 +1674,7 @@ class IoOps(AbstractOps):
 
         return True
 
-    def get_acl(self, host, path, filename):
+    def get_acl(self, host: str, path: str, filename: str):
         """Get all acl rules set to a file
 
         Args:

--- a/tests/functional/dht/test_rebalance_with_acl_set_to_files.py
+++ b/tests/functional/dht/test_rebalance_with_acl_set_to_files.py
@@ -1,0 +1,129 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.glusterfile import set_acl, get_acl
+from glustolibs.gluster.lib_utils import add_user, del_user
+from glustolibs.gluster.mount_ops import mount_volume
+from glustolibs.gluster.rebalance_ops import (
+    rebalance_start, wait_for_rebalance_to_complete)
+from glustolibs.gluster.volume_libs import expand_volume
+from glustolibs.io.utils import collect_mounts_arequal
+
+
+@runs_on([['distributed-replicated', 'distributed-arbiter', 'distributed',
+           'replicated', 'arbiter', 'distributed-dispersed',
+           'dispersed'], ['glusterfs']])
+class TestRebalanceWithAclSetToFiles(GlusterBaseClass):
+
+    def setUp(self):
+
+        self.get_super_method(self, 'setUp')()
+
+        # Setup Volume
+        if not self.setup_volume():
+            raise ExecutionError("Failed to Setup volume")
+
+        self.first_client = self.mounts[0].client_system
+        self.mount_point = self.mounts[0].mountpoint
+
+        # Mount volume with -o acl option
+        ret, _, _ = mount_volume(self.volname, self.mount_type,
+                                 self.mount_point, self.mnode,
+                                 self.first_client, options='acl')
+        if ret:
+            raise ExecutionError("Failed to mount volume")
+
+        # Create a non-root user
+        if not add_user(self.first_client, 'joker'):
+            raise ExecutionError("Failed to create user joker")
+
+    def tearDown(self):
+
+        # Remove non-root user created for test
+        if not del_user(self.first_client, 'joker'):
+            raise ExecutionError("Failed to remove user joker")
+
+        if not self.unmount_volume_and_cleanup_volume([self.mounts[0]]):
+            raise ExecutionError("Failed to Cleanup Volume")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()
+
+    def _check_acl_set_to_files(self):
+        """Check acl values set to files"""
+        for number in range(1, 11):
+            ret = get_acl(self.first_client, self.mount_point,
+                          'file{}'.format(str(number)))
+            self.assertIn('user:joker:rwx', ret['rules'],
+                          "Rule not present in getfacl output")
+
+    def test_add_brick_rebalance_with_acl_set_to_files(self):
+        """
+        Test case:
+        1. Create a volume, start it and mount it to a client.
+        2. Create 10 files on the mount point and set acls on the files.
+        3. Check the acl value and collect arequal-checksum.
+        4. Add bricks to the volume and start rebalance.
+        5. Check the value of acl(it should be same as step 3),
+           collect and compare arequal-checksum with the one collected
+           in step 3
+        """
+        # Create 10 files on the mount point.
+        cmd = ("cd {}; for i in `seq 1 10`;do touch file$i;done"
+               .format(self.mount_point))
+        ret, _, _ = g.run(self.first_client, cmd)
+        self.assertFalse(ret, "Failed to create files on mount point")
+
+        for number in range(1, 11):
+            ret = set_acl(self.first_client, 'u:joker:rwx', '{}/file{}'
+                          .format(self.mount_point, str(number)))
+            self.assertTrue(ret, "Failed to set acl on files")
+
+        # Collect arequal on mount point and check acl value
+        arequal_checksum_before = collect_mounts_arequal(self.mounts[0])
+        self._check_acl_set_to_files()
+        g.log.info("Files created and acl set to files properly")
+
+        # Add brick to volume
+        ret = expand_volume(self.mnode, self.volname, self.servers,
+                            self.all_servers_info)
+        self.assertTrue(ret, "Failed to add brick on volume %s"
+                        % self.volname)
+
+        # Trigger rebalance and wait for it to complete
+        ret, _, _ = rebalance_start(self.mnode, self.volname,
+                                    force=True)
+        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
+                         % self.volname)
+
+        # Wait for rebalance to complete
+        ret = wait_for_rebalance_to_complete(self.mnode, self.volname,
+                                             timeout=1200)
+        self.assertTrue(ret, "Rebalance is not yet complete on the volume "
+                             "%s" % self.volname)
+        g.log.info("Rebalance successfully completed")
+
+        # Check acl value if it's same as before rebalance
+        self._check_acl_set_to_files()
+
+        # Check for data loss by comparing arequal before and after ops
+        arequal_checksum_after = collect_mounts_arequal(self.mounts[0])
+        self.assertEqual(arequal_checksum_before, arequal_checksum_after,
+                         "arequal checksum is NOT MATCHNG")
+        g.log.info("arequal checksum and acl value are SAME")

--- a/tests/functional/dht/test_rebalance_with_acl_set_to_files.py
+++ b/tests/functional/dht/test_rebalance_with_acl_set_to_files.py
@@ -88,7 +88,7 @@ class TestRebalanceWithAclSetToFiles(DParentTest):
                 raise Exception("Failed to set acl on files")
 
         # Collect arequal on mount point and check acl value
-        arequal_checksum_before = redant.collect_mounts_arequal(self.mounts[0])
+        arequal_checksum_before = redant.collect_mounts_arequal(self.mounts)
         self._check_acl_set_to_files()
 
         # Add brick to volume
@@ -114,6 +114,6 @@ class TestRebalanceWithAclSetToFiles(DParentTest):
         self._check_acl_set_to_files()
 
         # Check for data loss by comparing arequal before and after ops
-        arequal_checksum_after = redant.collect_mounts_arequal(self.mounts[0])
+        arequal_checksum_after = redant.collect_mounts_arequal(self.mounts)
         if arequal_checksum_before != arequal_checksum_after:
             raise Exception("arequal checksum in NOT equal")

--- a/tests/functional/dht/test_rebalance_with_acl_set_to_files.py
+++ b/tests/functional/dht/test_rebalance_with_acl_set_to_files.py
@@ -1,79 +1,67 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.glusterfile import set_acl, get_acl
-from glustolibs.gluster.lib_utils import add_user, del_user
-from glustolibs.gluster.mount_ops import mount_volume
-from glustolibs.gluster.rebalance_ops import (
-    rebalance_start, wait_for_rebalance_to_complete)
-from glustolibs.gluster.volume_libs import expand_volume
-from glustolibs.io.utils import collect_mounts_arequal
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along`
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+
+# disruptive;dist-rep,dist-arb,dist,rep,arb,dist-disp,disp
+
+import traceback
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed-replicated', 'distributed-arbiter', 'distributed',
-           'replicated', 'arbiter', 'distributed-dispersed',
-           'dispersed'], ['glusterfs']])
-class TestRebalanceWithAclSetToFiles(GlusterBaseClass):
+class TestRebalanceWithAclSetToFiles(DParentTest):
 
-    def setUp(self):
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
+        """
+        Override the volume create, start and mount in parent_run_test
+        """
+        conf_hash = self.vol_type_inf[self.volume_type]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots, force=True)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        self.redant.execute_abstract_op_node(f"mkdir -p "
+                                             f"{self.mountpoint}",
+                                             self.client_list[0])
+        self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                 self.mountpoint, self.client_list[0],
+                                 option='acl')
 
-        self.get_super_method(self, 'setUp')()
-
-        # Setup Volume
-        if not self.setup_volume():
-            raise ExecutionError("Failed to Setup volume")
-
-        self.first_client = self.mounts[0].client_system
-        self.mount_point = self.mounts[0].mountpoint
-
-        # Mount volume with -o acl option
-        ret, _, _ = mount_volume(self.volname, self.mount_type,
-                                 self.mount_point, self.mnode,
-                                 self.first_client, options='acl')
-        if ret:
-            raise ExecutionError("Failed to mount volume")
-
-        # Create a non-root user
-        if not add_user(self.first_client, 'joker'):
-            raise ExecutionError("Failed to create user joker")
-
-    def tearDown(self):
-
-        # Remove non-root user created for test
-        if not del_user(self.first_client, 'joker'):
-            raise ExecutionError("Failed to remove user joker")
-
-        if not self.unmount_volume_and_cleanup_volume([self.mounts[0]]):
-            raise ExecutionError("Failed to Cleanup Volume")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+    def terminate(self):
+        """
+        Delete the users created in the TC
+        """
+        try:
+            self.redant.del_user(self.client_list[0], "joker")
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
     def _check_acl_set_to_files(self):
         """Check acl values set to files"""
         for number in range(1, 11):
-            ret = get_acl(self.first_client, self.mount_point,
-                          'file{}'.format(str(number)))
-            self.assertIn('user:joker:rwx', ret['rules'],
-                          "Rule not present in getfacl output")
+            ret = self.redant.get_acl(self.client_list[0], self.mountpoint,
+                                      f'file{number}')
+            if 'user:joker:rwx\n' not in ret['msg']:
+                raise Exception("Rule not present in getfacl output")
 
-    def test_add_brick_rebalance_with_acl_set_to_files(self):
+    def run_test(self, redant):
         """
         Test case:
         1. Create a volume, start it and mount it to a client.
@@ -84,46 +72,48 @@ class TestRebalanceWithAclSetToFiles(GlusterBaseClass):
            collect and compare arequal-checksum with the one collected
            in step 3
         """
+        self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
+        # Create user
+        if not redant.add_user(self.client_list[0], 'joker'):
+            raise Exception("Failed to create user joker")
+
         # Create 10 files on the mount point.
-        cmd = ("cd {}; for i in `seq 1 10`;do touch file$i;done"
-               .format(self.mount_point))
-        ret, _, _ = g.run(self.first_client, cmd)
-        self.assertFalse(ret, "Failed to create files on mount point")
+        cmd = (f"cd {self.mountpoint}; for i in `seq 1 10`;do touch file$i;"
+               "done")
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         for number in range(1, 11):
-            ret = set_acl(self.first_client, 'u:joker:rwx', '{}/file{}'
-                          .format(self.mount_point, str(number)))
-            self.assertTrue(ret, "Failed to set acl on files")
+            if not (redant.set_acl(self.client_list[0], 'u:joker:rwx',
+                    f'{self.mountpoint}/file{number}')):
+                raise Exception("Failed to set acl on files")
 
         # Collect arequal on mount point and check acl value
-        arequal_checksum_before = collect_mounts_arequal(self.mounts[0])
+        arequal_checksum_before = redant.collect_mounts_arequal(self.mounts[0])
         self._check_acl_set_to_files()
-        g.log.info("Files created and acl set to files properly")
 
         # Add brick to volume
-        ret = expand_volume(self.mnode, self.volname, self.servers,
-                            self.all_servers_info)
-        self.assertTrue(ret, "Failed to add brick on volume %s"
-                        % self.volname)
+        ret = redant.expand_volume(self.server_list[0],
+                                   self.vol_name, self.server_list,
+                                   self.brick_roots, force=True)
+        if not ret:
+            raise Exception("Failed to expand volume")
 
         # Trigger rebalance and wait for it to complete
-        ret, _, _ = rebalance_start(self.mnode, self.volname,
-                                    force=True)
-        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
-                         % self.volname)
+        redant.rebalance_start(self.vol_name, self.server_list[0],
+                               force=True)
 
         # Wait for rebalance to complete
-        ret = wait_for_rebalance_to_complete(self.mnode, self.volname,
-                                             timeout=1200)
-        self.assertTrue(ret, "Rebalance is not yet complete on the volume "
-                             "%s" % self.volname)
-        g.log.info("Rebalance successfully completed")
+        ret = redant.wait_for_rebalance_to_complete(self.vol_name,
+                                                    self.server_list[0],
+                                                    timeout=1200)
+        if not ret:
+            raise Exception("Rebalance is not yet complete on the volume "
+                            f"{self.vol_name}")
 
         # Check acl value if it's same as before rebalance
         self._check_acl_set_to_files()
 
         # Check for data loss by comparing arequal before and after ops
-        arequal_checksum_after = collect_mounts_arequal(self.mounts[0])
-        self.assertEqual(arequal_checksum_before, arequal_checksum_after,
-                         "arequal checksum is NOT MATCHNG")
-        g.log.info("arequal checksum and acl value are SAME")
+        arequal_checksum_after = redant.collect_mounts_arequal(self.mounts[0])
+        if arequal_checksum_before != arequal_checksum_after:
+            raise Exception("arequal checksum in NOT equal")


### PR DESCRIPTION
Migrate TC [test_rebalance_with_acl_set_to_files.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/dht/test_rebalance_with_acl_set_to_files.py)

Updates: #292
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>