### PR TITLE
[Commom] Updated the reboot_node code

### DIFF
--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -25,7 +25,9 @@ class MachineOps(AbstractOps):
             nodes = [nodes]
 
         for node in nodes:
-            self.reboot_node(node)
+            ret = self.reboot_node(node)
+            if not ret:
+                raise Exception(f"Failed to reboot node {node}")
             self.wait_node_power_down(node)
 
     def check_node_power_status(self, nodes: list) -> dict:

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -307,13 +307,16 @@ class Rexe:
 
     def reboot_node(self, node):
         """
-        Reboot of a node is a special case and the normal execute_command
-        will throw an error.
+        Reboot of a node is a special case and we need to execute his using
+        paramiko `exec_command` directly.
         Arg:
             node (str)
         """
-        cmd = (f'ssh -t root@{node} "sleep 1;reboot > /dev/null 2>&1;"'
-               ' > /dev/null 2>&1;')
-        self.logger.info(f"Executing the command : {cmd}")
-        ret = os.system(cmd)
-        self.logger.info(f"Return value for the command {cmd} is {ret}")
+        self.logger.info(f"Rebooting node: {node} ...")
+        cmd = "reboot"
+        try:
+            _, _, stderr = self.node_dict[node].exec_command(cmd)
+        except Exception:
+            # In case command execution fails, handle exception
+            self.logger.error("Failed to execute 'reboot' command"
+                              f"Error: {stderr}")

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -305,12 +305,15 @@ class Rexe:
         sftp.put(source_path, dest_path)
         sftp.close()
 
-    def reboot_node(self, node):
+    def reboot_node(self, node: str) -> bool:
         """
         Reboot of a node is a special case and we need to execute his using
         paramiko `exec_command` directly.
         Arg:
             node (str)
+        Returns:
+            bool: True in case command execution was success.
+                  False otherwise
         """
         self.logger.info(f"Rebooting node: {node} ...")
         cmd = "reboot"
@@ -320,3 +323,6 @@ class Rexe:
             # In case command execution fails, handle exception
             self.logger.error("Failed to execute 'reboot' command"
                               f"Error: {stderr}")
+            return False
+
+        return True

--- a/config/config.yml
+++ b/config/config.yml
@@ -54,7 +54,6 @@ volume_types:
         
 #excluded_tests - Tests which are excluded during the test run.
 excluded_tests:
-    - tests/functional/glusterd/test_shared_storage.py # Reboot hangs redant flow in this TC.
     - tests/functional/afr/test_brick_process_not_started_on_read_only_node_disks.py # Inactive TC.
     - tests/functional/afr/test_client_side_quorum_fixed_with_cross2.py # TC is bogus, as setting quorum count: 2 for replica 2 volume and bringing one brick down will give transport errors
     - tests/functional/afr/test_arb_to_repl_conversion_with_io.py # Heal not completing even after increasing the timeout and the IO is completed


### PR DESCRIPTION
### Description:
Updated the `reboo_node` function to use the paramiko `exec_command` function directly, and raise an
exception in case of an issue.
The reason to not use the existing `execute_command` function is, that function tries to reconnect to the node, in case of an exception which we don't want in this case.

Fixes: #940 

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
