### PR TITLE
Added sleep in some TCs to compensate for mounting of volume after a restart

### DIFF
--- a/common/ops/gluster_ops/heal_ops.py
+++ b/common/ops/gluster_ops/heal_ops.py
@@ -99,8 +99,10 @@ class HealOps:
         failure_msg = ("Verifying all self-heal-daemons are online failed for "
                        f"volume {volname}")
         # Get volume status
-        vol_status = self.get_volume_status(volname, node, service)
-        if vol_status is None:
+        vol_status = self.get_volume_status(volname, node, service,
+                                            excep=False)
+        if vol_status is None or ('msg' in vol_status
+           and vol_status['msg']['opRet'] != '0'):
             self.logger.error(failure_msg)
             return None
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -263,8 +263,8 @@ class VolumeOps(AbstractOps):
         ret = self.execute_abstract_op_node(cmd, node, excep)
 
         if not excep and (ret['error_code'] != 0
-            or ret['msg']['opRet'] != '0'):
-                return ret
+           or ret['msg']['opRet'] != '0'):
+            return ret
 
         self.es.set_volume_start_status(volname, True)
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -262,8 +262,9 @@ class VolumeOps(AbstractOps):
 
         ret = self.execute_abstract_op_node(cmd, node, excep)
 
-        if not excep and ret['msg']['opRet'] != '0':
-            return ret
+        if not excep and (ret['error_code'] != 0
+            or ret['msg']['opRet'] != '0'):
+                return ret
 
         self.es.set_volume_start_status(volname, True)
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -80,6 +80,7 @@ excluded_tests:
     - tests/functional/glusterd/test_rebalance_start_not_failed_with_socket_path_too_long.py # Doesn't work on RHGS installation
     - tests/functional/glusterd/test_glusterd_selinux.py # Issue with SELinux in CI
     - tests/functional/glusterd/test_glusterd_memory_consumption_increase.py # Memory consumption not consistent
+    - tests/functional/glusterd/test_shared_storage.py # Fails in CI, because of a known issue with shared_storage mounting after reboot in env having ipv6 enabled
     - tests/functional/ctime_feature/test_consistent_timestamps_on_new_entries.py # Probability of time being same is very rare
     - tests/functional/resource_leak/test_verify_gluster_memleak_with_ssl.py # Takes more than 12hrs to completely run the TC
     - tests/functional/resource_leak/test_verify_gluster_memleak_with_management_encryption.py # Takes more than 12hrs to completely run the TC

--- a/tests/functional/afr/heal/test_data_split_brain_resolution.py
+++ b/tests/functional/afr/heal/test_data_split_brain_resolution.py
@@ -23,6 +23,7 @@ Description:
 
 # disruptive;rep
 from copy import deepcopy
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -113,6 +114,9 @@ class TestCase(DParentTest):
         if not redant.are_bricks_offline(self.vol_name, bricks_list[1],
                                          self.server_list[1]):
             raise Exception(f"Brick {bricks_list[1]} is not offline")
+
+        # Allow volume to mount after the bricks are up
+        sleep(5)
 
         # Modify the contents of the files
         cmd = ("for i in `seq 1 10`; do for j in `seq 1 5`;"

--- a/tests/functional/afr/heal/test_metadata_split_brain_resolution.py
+++ b/tests/functional/afr/heal/test_metadata_split_brain_resolution.py
@@ -23,6 +23,7 @@
 
 # disruptive;rep
 from copy import deepcopy
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -133,6 +134,9 @@ class TestCase(DParentTest):
         if not redant.are_bricks_offline(self.vol_name, bricks_list[1],
                                          self.server_list[1]):
             raise Exception(f"Brick {bricks_list[1]} is not offline")
+
+        # Allow volume to mount after the bricks are up
+        sleep(5)
 
         # Change metadata of same files & directories as before
         cmd = (f"cd {self.mountpoint}/test_metadata_sb && "

--- a/tests/functional/afr/test_afr_cli_gfid_splitbrain.py
+++ b/tests/functional/afr/test_afr_cli_gfid_splitbrain.py
@@ -102,6 +102,10 @@ class TestCase(DParentTest):
                                           [all_bricks[0]]):
             raise Exception(f"unable to bring {all_bricks[0]} online")
 
+        if not redant.are_bricks_online(self.vol_name, [all_bricks[0]],
+                                        self.server_list[0]):
+            raise Exception("Bricks are not yet online")
+
         if not redant.bring_bricks_offline(self.vol_name, all_bricks[1]):
             raise Exception(f"unable to bring {all_bricks[1]} offline")
 

--- a/tests/functional/afr/test_dir_gfid_heal_on_all_subvols.py
+++ b/tests/functional/afr/test_dir_gfid_heal_on_all_subvols.py
@@ -22,7 +22,7 @@ Description:
 
 """
 
-# disruptive;rep,dist-rep,dist
+# disruptive;rep,dist-rep
 from time import sleep
 from tests.d_parent_test import DParentTest
 

--- a/tests/functional/afr/test_gfid_split_brain_resolution.py
+++ b/tests/functional/afr/test_gfid_split_brain_resolution.py
@@ -127,6 +127,11 @@ class TestSelfHeal(DParentTest):
                                               list(bricks)):
                 raise Exception("Failed to bring bricks online")
 
+            # Confirm if the bricks are online
+            if not redant.are_bricks_online(self.vol_name, list(bricks),
+                                            self.server_list[0]):
+                raise Exception("Bricks are not yet online")
+
         # Enable self-heal daemon, trigger heal and assert volume is in split
         # brain condition
         if not redant.enable_self_heal_daemon(self.vol_name,

--- a/tests/functional/afr/test_heal_split_brain_command.py
+++ b/tests/functional/afr/test_heal_split_brain_command.py
@@ -132,6 +132,11 @@ class TestSplitBrain(DParentTest):
                                               list(bricks)):
                 raise Exception(f'Unable to bring {bricks} online')
 
+            # Confirm if the bricks are online
+            if not redant.are_bricks_online(self.vol_name, list(bricks),
+                                            self.server_list[0]):
+                raise Exception("Bricks are not yet online")
+
         # Validate volume is in split-brain
         if not redant.is_volume_in_split_brain(self.server_list[0],
                                                self.vol_name):

--- a/tests/functional/afr/test_split_brain_with_hard_link_file.py
+++ b/tests/functional/afr/test_split_brain_with_hard_link_file.py
@@ -21,7 +21,7 @@ Description:
 """
 
 # disruptive;dist-rep
-
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -47,6 +47,9 @@ class TestCase(DParentTest):
         if not self.redant.are_bricks_online(self.vol_name, [brick],
                                              self.server_list[0]):
             raise Exception(f"Brick {brick} is not online.")
+
+        # Adding sleep to allow volume to mount on client after brick is up
+        sleep(2)
 
     def run_test(self, redant):
         """

--- a/tests/functional/arbiter/test_no_data_loss_arbiter_vol_after_rename_file.py
+++ b/tests/functional/arbiter/test_no_data_loss_arbiter_vol_after_rename_file.py
@@ -21,7 +21,7 @@ Description:
 """
 
 # disruptive;arb
-
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -118,6 +118,12 @@ class TestCase(DParentTest):
         bricks_to_bring_online = [bricks_list[0]]
         redant.bring_bricks_online(self.vol_name, self.server_list,
                                    bricks_to_bring_online)
+        if not redant.are_bricks_online(self.vol_name, bricks_to_bring_online,
+                                        self.server_list[0]):
+            raise Exception("Bricks are not yet online")
+
+        # Buffer to allow volume to be mounted
+        sleep(4)
 
         # Rename file under test_dir
         if not (redant.

--- a/tests/functional/arbiter/test_oom_on_client_heal_is_in_progress_arbiter.py
+++ b/tests/functional/arbiter/test_oom_on_client_heal_is_in_progress_arbiter.py
@@ -23,6 +23,7 @@ Description:
 # TODO: add nfs and cifs
 
 import traceback
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -103,6 +104,9 @@ class TestCase(DParentTest):
         # Bring brick 3 offline and then online
         bricks_to_bring_offline = [bricks_list[-1]]
         self._brick_operations(bricks_to_bring_offline)
+
+        # Buffer to allow volume to be mounted
+        sleep(4)
 
         # Get file list from mountpoint
         for mount_obj in self.mnt_list:

--- a/tests/functional/arbiter/test_resolving_meta_data_split_brain_extended_attributes.py
+++ b/tests/functional/arbiter/test_resolving_meta_data_split_brain_extended_attributes.py
@@ -24,6 +24,7 @@ Description:
 # TODO: nfs, cifs
 
 import traceback
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -129,6 +130,9 @@ class TestCase(DParentTest):
         # Bring arbiter brick offline
         bricks_to_bring_offline = [brick_list_with_file[-1]]
         self._brick_and_io(bricks_to_bring_offline, "600")
+
+        # Buffer to allow volume to be mounted
+        sleep(4)
 
         # Bring 1-st data brick offline
         bricks_to_bring_offline = [brick_list_with_file[0]]

--- a/tests/functional/arbiter/test_verify_metadata_and_data_heal.py
+++ b/tests/functional/arbiter/test_verify_metadata_and_data_heal.py
@@ -22,6 +22,7 @@
 
 # disruptive;arb,rep
 import traceback
+from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -254,6 +255,9 @@ class TestSelfHeal(DParentTest):
             if not self.redant.are_bricks_online(self.vol_name, brick,
                                                  self.server_list[0]):
                 raise Exception(f"Brick {brick} is not online")
+
+            # Buffer to allow volume to be mounted
+            sleep(4)
 
         # Confirm metadata/data operations resulted in pending heals
         if self.redant.is_heal_complete(self.server_list[0], self.vol_name):

--- a/tests/functional/glusterd/test_default_max_bricks_per_process.py
+++ b/tests/functional/glusterd/test_default_max_bricks_per_process.py
@@ -42,7 +42,7 @@ class TestCase(DParentTest):
         """
         # Fetch the max bricks per process value
         ret = redant.get_volume_options(node=self.server_list[0])
-        initial_value = ret['cluster.max-bricks-per-process']
+        initial_value = ret['cluster.max-bricks-per-process'].split()[0]
 
         # Reset the volume options
         redant.reset_volume_option('all', 'all', self.server_list[0])


### PR DESCRIPTION
**Description:**
Marked the TC `test_shared_storage` as excluded and added sleep in some TCs to compensate
for a remount of volume after a restart of bricks for a volume. 
**NOTE:""
It is not ideal to add a sleep for in these TCs, but it has been done to adjust for all types of env and gluster installation.

Signed-off-by: nik-redhat <nladha@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
