### PR TITLE
Fix: get_volume_type_from_brick function

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -989,22 +989,23 @@ class VolumeOps(AbstractOps):
                 self.logger.error("Failed to get the brick list for volume")
                 return None
 
-            brick_paths = [brick.split(':')[1] for brick in brick_list]
-            if path_info in brick_paths:
-                ret = self.get_volume_info(host, volume)
-                if not ret:
-                    self.logger.error("Failed to get volume type for "
-                                      f"{volume}")
-                    return None
-                list_of_replica = ('Replicate', 'Distributed-Replicate')
-                if (ret[volume]['typeStr'] in list_of_replica
-                   and int(ret[volume]['arbiterCount']) == 1):
-                    if int(ret[volume]['distCount']) >= 2:
-                        return 'Distributed-Arbiter'
+            for brick in brick_list:
+                brick_path = brick.split(':')[1]
+                if brick_path in path_info:
+                    ret = self.get_volume_info(host, volume)
+                    if not ret:
+                        self.logger.error("Failed to get volume type for "
+                                          f"{volume}")
+                        return None
+                    list_of_replica = ('Replicate', 'Distributed-Replicate')
+                    if (ret[volume]['typeStr'] in list_of_replica
+                       and int(ret[volume]['arbiterCount']) == 1):
+                        if int(ret[volume]['distCount']) >= 2:
+                            return 'Distributed-Arbiter'
+                        else:
+                            return 'Arbiter'
                     else:
-                        return 'Arbiter'
-                else:
-                    return ret[volume]['typeStr']
+                        return ret[volume]['typeStr']
 
         self.logger.error("Failed to find volume type for brick-path "
                           f"{brickdir_path}")


### PR DESCRIPTION
### All Submissions:

**Description:**
The brick_path which was checked against the bricks from the volume_info consists of the file/folder names as well.
As a result the type check always used to fail out. 
Hence, modified the check to check for bricks from volume info in the given path. (Vice versa of the current check)

Signed-off-by: nik-redhat <nladha@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
