### PR TITLE
Core: Fix vol type check in test list builder

### DIFF
--- a/core/test_list_builder.py
+++ b/core/test_list_builder.py
@@ -51,9 +51,12 @@ class TestListBuilder:
         path.
         Args:
             path (str): The directory path which contains the TCs
-            to be run.
+                        to be run.
+            excluded_tests (list): List of excluded TCs in the config file
+            volume_types_config (dict): Dict of volume types added in the
+                                        config file
             single_tc (bool): If the user wants to run a single TC instead
-            of the complete suite.
+                              of the complete suite.
         Returns:
         """
         def path_error_handler(exception_instance):
@@ -93,8 +96,8 @@ class TestListBuilder:
                     if vol_type not in valid_vol_types:
                         raise Exception(f"{test_dict['modulePath']} has"
                                         f" invalid volume type {vol_type}")
-                    if ((vol_type != "Generic")
-                       and (vol_type in volume_types_config)):
+                    if ((vol_type == "Generic")
+                       or (vol_type in volume_types_config)):
                         temp_test_dict = copy.deepcopy(test_dict)
                         temp_test_dict["volType"] = copy.deepcopy(vol_type)
                         cls.dtest_list.append(temp_test_dict)
@@ -103,8 +106,8 @@ class TestListBuilder:
                     if vol_type not in valid_vol_types:
                         raise Exception(f"{test_dict['modulePath']} has"
                                         f" invalid volume type {vol_type}")
-                    if ((vol_type != "Generic")
-                       and (vol_type in volume_types_config)):
+                    if ((vol_type == "Generic")
+                       or (vol_type in volume_types_config)):
                         temp_test_dict = copy.deepcopy(test_dict)
                         cls.nd_category[vol_type].append(temp_test_dict)
             else:

--- a/tests/functional/dht/test_verify_permissions_on_root_dir_when_brick_down.py
+++ b/tests/functional/dht/test_verify_permissions_on_root_dir_when_brick_down.py
@@ -16,7 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-# nonDisruptive;dist,dist-rep,dist-disp,dist-arb
+# disruptive;dist,dist-rep,dist-disp,dist-arb
 import traceback
 from tests.nd_parent_test import NdParentTest
 

--- a/tests/functional/dht/test_verify_permissions_on_root_dir_when_brick_down.py
+++ b/tests/functional/dht/test_verify_permissions_on_root_dir_when_brick_down.py
@@ -18,10 +18,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 # disruptive;dist,dist-rep,dist-disp,dist-arb
 import traceback
-from tests.nd_parent_test import NdParentTest
+from tests.d_parent_test import DParentTest
 
 
-class TestCase(NdParentTest):
+class TestCase(DParentTest):
     def terminate(self):
         """
         Wait for IO to complete if the TC fails midway
@@ -135,4 +135,4 @@ class TestCase(NdParentTest):
         self._verify_mount_dir_and_brick_dir_permissions("755")
 
         redant.logger.info("Test to verify permission changes made on"
-                           " mount dir i succesful")
+                           " mount dir is succesful")


### PR DESCRIPTION
Signed-off-by: nik-redhat <nladha@redhat.com>

### All Submissions:

**Description:**
The condition to check for config was incorrect, it filtered out the "Genric" volumes as well.
Updated the code to use "OR" instead of "AND" for the check.
Also, updated a DHT tc to `disruptive` type as it restarted glusterd in the test.

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
