### PR TITLE
Marked arbiter, glusterd,disperse modules for upstream TCs

### DIFF
--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -435,6 +435,8 @@ class MachineOps(AbstractOps):
 
         Args:
             servers (list): List of server nodes
+            inst_type (str): Type of gluster installation for which
+                             the TC works
 
         NOTE: This might not be the best way to check, but it works
               for now

--- a/tests/functional/arbiter/test_resolving_meta_data_split_brain_extended_attributes.py
+++ b/tests/functional/arbiter/test_resolving_meta_data_split_brain_extended_attributes.py
@@ -30,6 +30,24 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
+        # Skip if upstream installation
+        self.redant.check_gluster_installation(self.server_list, "downstream")
+
+        # Create and start the volume
+        conf_hash = self.vol_type_inf[self.volume_type]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots, force=True)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        for client in self.client_list:
+            self.redant.execute_abstract_op_node("mkdir -p "
+                                                 f"{self.mountpoint}",
+                                                 client)
+            self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                     self.mountpoint, client)
+
     def terminate(self):
         try:
             ret = self.redant.wait_for_io_to_complete(self.list_of_procs,

--- a/tests/functional/arbiter/test_self_heal_symbolic_links.py
+++ b/tests/functional/arbiter/test_self_heal_symbolic_links.py
@@ -26,6 +26,24 @@ from tests.d_parent_test import DParentTest
 
 class TestSelfHeal(DParentTest):
 
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
+        # Skip if upstream installation
+        self.redant.check_gluster_installation(self.server_list, "downstream")
+
+        # Create and start the volume
+        conf_hash = self.vol_type_inf[self.volume_type]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots, force=True)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        for client in self.client_list:
+            self.redant.execute_abstract_op_node("mkdir -p "
+                                                 f"{self.mountpoint}",
+                                                 client)
+            self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                     self.mountpoint, client)
+
     def run_test(self, redant):
         """
         Description:

--- a/tests/functional/arbiter/test_split_brain.py
+++ b/tests/functional/arbiter/test_split_brain.py
@@ -27,6 +27,24 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
+    def setup_test(self):
+        # Skip if upstream installation
+        self.redant.check_gluster_installation(self.server_list, "downstream")
+
+        # Create and start the volume
+        conf_hash = self.vol_type_inf[self.volume_type]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots, force=True)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        for client in self.client_list:
+            self.redant.execute_abstract_op_node("mkdir -p "
+                                                 f"{self.mountpoint}",
+                                                 client)
+            self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                     self.mountpoint, client)
+
     def _perform_io(self, passed: bool):
         # Write IO's
         self.proc = (self.redant.

--- a/tests/functional/disperse/test_ec_io_hang_clientside_heal.py
+++ b/tests/functional/disperse/test_ec_io_hang_clientside_heal.py
@@ -32,6 +32,9 @@ class TestCase(NdParentTest):
         3. Check that the heal should complete via client side heal and it
         should not hang any IO.
         """
+        # Skip if upstream installation
+        redant.check_gluster_installation(self.server_list, "downstream")
+
         # disable server side heal
         ret = redant.disable_heal(self.server_list[0], self.vol_name)
         if not ret:

--- a/tests/functional/glusterd/test_validate_glusterd_info.py
+++ b/tests/functional/glusterd/test_validate_glusterd_info.py
@@ -38,6 +38,9 @@ class TestGlusterdInfo(NdParentTest):
                 ls  /var/run/ | grep -i glusterd.socket
             6. systemctl is-enabled glusterd -> enabled
         """
+        # Skip if upstream installation
+        self.redant.check_gluster_installation(self.server_list, "downstream")
+
         for server in self.server_list:
 
             # Getting UUID from glusterd.info


### PR DESCRIPTION
Signed-off-by: nik-redhat <nladha@redhat.com>

### Description:

This PR covers glusterd, disperse, arbiter modules for upstream TCs.
After this, only AFR and DHT would be left.


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
